### PR TITLE
Add codebase wiki

### DIFF
--- a/wiki/SCHEMA.md
+++ b/wiki/SCHEMA.md
@@ -1,0 +1,49 @@
+# tf2jax Wiki Schema
+
+This wiki captures deep knowledge about the tf2jax codebase. It is maintained by Claude Code and read by developers.
+
+## Directory structure
+
+```
+wiki/
+  SCHEMA.md          ← this file: conventions and workflows
+  index.md           ← content-oriented catalog of all pages
+  log.md             ← append-only chronological record
+  overview.md        ← architecture overview and entry point
+
+  concepts/          ← design concepts, mechanisms, patterns
+  entities/          ← specific classes, functions, modules
+  design/            ← design proposals, refactoring notes, trade-off records
+```
+
+## Page conventions
+
+- Every page starts with a `# Title` heading and a one-line description in italics.
+- Cross-links use `[[PageName]]` style anchors rendered as `[PageName](../path/to/page.md)`.
+- Every concept/entity page has a **Source** line pointing to the file:line range.
+- Code snippets are kept short — illustrative, not exhaustive.
+- Pages in `design/` capture intent and reasoning, not just what the code does.
+
+## Operations
+
+**Ingest** (adding new knowledge from the codebase):
+1. Read the relevant source file(s).
+2. Create or update the entity/concept page.
+3. Update `index.md` with a new entry.
+4. Add a log entry to `log.md`.
+5. Update cross-links on related pages.
+
+**Query** (answering questions):
+1. Read `index.md` to find relevant pages.
+2. Read the relevant pages.
+3. Synthesize an answer. If the answer is generally useful, file it as a new page in `design/`.
+
+**Lint** (periodic health check):
+- Look for orphan pages (no inbound links).
+- Look for concepts mentioned but lacking their own page.
+- Look for stale claims after code changes.
+- Suggest new questions and sources.
+
+## Source of truth
+
+The source of truth is always the codebase at `/Users/shaobohou/Downloads/projects/tf2jax/`. Wiki pages may become stale after refactoring — always verify file:line references before acting on them.

--- a/wiki/concepts/conversion-phases.md
+++ b/wiki/concepts/conversion-phases.md
@@ -1,0 +1,79 @@
+# Conversion Phases
+
+*The most important mental model: build time and run time are two distinct phases, both implemented inside `_convert()` and the closure it returns.*
+
+**Source:** `tf2jax/_src/tf2jax.py:976–1285`
+
+## Overview
+
+`_convert()` is a function that:
+1. Does a lot of work upfront (build time), then
+2. Returns a `jax_func` closure that captures all that work (run time).
+
+A reader must always know which phase they are in. Code above the `def jax_func(...)` definition runs once at conversion time. Code inside `jax_func` runs on every call.
+
+## Build time (inside `_convert`, before `def jax_func`)
+
+In order:
+
+1. **Recurse into FunctionDefLibrary** — any library functions referenced by the graph are converted first and stored in `library: dict[str, _LibraryFunction]`. Each is wrapped in a `_CachedBuilder` for lazy JAX compilation.
+
+2. **Canonicalise inputs/outputs** — flat lists of `input_names`, `input_path_to_specs`, `output_names` are extracted from `structured_inputs`/`structured_outputs`. These are the node names used as keys in the evaluation cache at run time.
+
+3. **Extract variables** — `variable_map` (ref → `tf.Variable`) is evaluated eagerly: `v.numpy()` is called and the result is stored as `Variable` (a NumPy subclass). Two index structures are built: `var_by_node` (node name → variable name) and `node_by_var` (variable name → node name). These are needed at run time to connect `AssignVariableOp` outputs back to the parameter dict.
+
+4. **Topological sort** — `_toposort(node_map, output_names)` produces the ordered list of `NodeDef` protos. Only nodes reachable from outputs are included.
+
+5. **Build `_OpNode` wrappers** — each sorted proto becomes an `_OpNode`. The constructor calls `ops.get_parser(proto.op)(proto)` which bakes static attributes (strides, padding, axis, dtype, etc.) into a closure that is stored as `node.jax_func`.
+
+6. **Relu inference heuristic** — if `infer_relu_from_jax2tf` is set, `_infer_relu_from_jax2tf(nodes)` mutates matching `Maximum` nodes into `Relu` nodes in-place.
+
+7. **Custom gradient subgraph extraction** — if `convert_custom_gradient` is set, `_extract_subgraphs(graphdef, nodes, library)` detects `IdentityN` nodes (the TF custom gradient marker), extracts the surrounding computation, and calls `subgraph.rewrite(nodes)` to replace affected `_OpNode`s with a single `_Subgraph` object.
+
+After step 7, `nodes` is a `list[_OpNode | _Subgraph]`. Both implement the same calling protocol (see [entities/_OpNode.md](../entities/_OpNode.md) and [entities/_Subgraph.md](../entities/_Subgraph.md)).
+
+## What the closure captures
+
+The `jax_func` closure closes over these 12 build-time variables:
+
+| Variable | Type | Purpose |
+|----------|------|---------|
+| `nodes` | `list[_OpNode \| _Subgraph]` | ordered execution sequence |
+| `num_rng_required` | `int` | how many random ops need RNG keys |
+| `input_path_to_specs` | `list[(path, TensorSpec)]` | maps arg paths → tensor names |
+| `input_names` | `tuple[str]` | names for user-provided inputs |
+| `captured_input_names` | `tuple[str]` | names for variable/constant captures |
+| `constants` | `dict[str, ndarray]` | constant tensors by node name |
+| `var_by_node` | `dict[str, str]` | node name → parameter name |
+| `node_by_var` | `dict[str, str]` | parameter name → node name |
+| `flat_output_specs` | `list` | output structure with TensorSpec leaves |
+| `structured_outputs` | nested | for `tree.unflatten_as` at the end |
+| `output_args` | `list[_TensorEdge]` | which cache entries are outputs |
+| `signature` | `inspect.Signature` | for `signature.bind(*args, **kwargs)` |
+
+> **Refactoring note:** These 12 implicit captures are a major cognitive load. A `_CompiledGraph` class with these as explicit `self.` fields would make the data model visible. See [design/refactoring-recommendations.md](../design/refactoring-recommendations.md).
+
+## Run time (inside `jax_func`)
+
+1. **Bind and flatten args** — `signature.bind(*func_args, **func_kwargs)` + `bound_args.apply_defaults()` → `inputs` (flat tuple of arrays).
+
+2. **Validate inputs** — shape check (`strict_shape_check`) and dtype check (`strict_dtype_check`) against the stored specs.
+
+3. **Assemble full inputs** — user inputs + captured params/constants → `full_inputs: list[(name, value)]`.
+
+4. **Split RNG** — `jax.random.split(rng, num_rng_required)` if any random ops exist.
+
+5. **Evaluation loop** — for each node in topological order, collect its inputs from `eval_cache.outputs`, call the node, store outputs back, free consumed intermediates (reference counting in `_EvaluationCache`). See [concepts/graph-evaluation.md](graph-evaluation.md).
+
+6. **Reconstruct outputs** — tensor outputs are unflattened using `structured_outputs` and non-tensor outputs (pass-through specs) are reinserted.
+
+7. **Return updated params** — for each variable in `params`, the latest value is read from `eval_cache.outputs[node_by_var[var_name]]`.
+
+## Related pages
+
+- [overview.md](../overview.md)
+- [concepts/graph-evaluation.md](graph-evaluation.md)
+- [concepts/library-functions.md](library-functions.md)
+- [concepts/custom-gradients.md](custom-gradients.md)
+- [entities/_OpNode.md](../entities/_OpNode.md)
+- [design/refactoring-recommendations.md](../design/refactoring-recommendations.md)

--- a/wiki/concepts/custom-gradients.md
+++ b/wiki/concepts/custom-gradients.md
@@ -1,0 +1,105 @@
+# Custom Gradients
+
+*tf2jax supports `@tf.custom_gradient` by detecting TF's `IdentityN` marker nodes, extracting the surrounding subgraph, and re-wrapping it with `jax.custom_gradient`.*
+
+**Source:** `tf2jax/_src/tf2jax.py:739–874` (subgraph extraction), `606–711` (`_Subgraph`), `1395–1532` (gradient function conversion)
+
+## How TF implements `@tf.custom_gradient`
+
+When TF traces a function decorated with `@tf.custom_gradient`, it inserts an `IdentityN` node into the graph. This node:
+- Passes its inputs through unchanged (identity)
+- Has a `_gradient_op_type` attribute naming the registered gradient function
+- Receives as inputs: `[fn_outputs..., fn_inputs...]` — both the outputs of the decorated function and its inputs (so the gradient function can access them)
+
+tf2jax detects these `IdentityN` nodes and reconstructs the original intent.
+
+## Pipeline
+
+### 1. Gradient function conversion (in `convert()`)
+
+```python
+if config.get_config("convert_custom_gradient"):
+    _convert_all_gradient_functions(graph, library)
+```
+
+`_convert_all_gradient_functions` finds all `IdentityN` nodes in the graph (including in library functions), and for each calls `_convert_gradient_function(proto, graph, library)`.
+
+`_convert_gradient_function`:
+1. Looks up the registered gradient function: `tf_ops.gradient_registry.lookup(grad_fn_name)`
+2. Wraps it in a `@tf.function` and calls `get_concrete_function(*input_specs)` — **this is the expensive TF trace**
+3. Extracts metadata: `external_capture_specs`, `internal_capture_names`, output specs
+4. Creates a `_LibraryFunction` with a `_CachedBuilder` whose builder calls `_convert()` on the gradient graph — **JAX conversion is lazy**
+
+> **Eagerness issue:** Step 2 (TF tracing) runs at `convert()` time even if the user never requests gradients. See [design/lazy-custom-gradients.md](../design/lazy-custom-gradients.md) for the design to fix this.
+
+### 2. Subgraph extraction (in `_convert()`)
+
+```python
+if config.get_config("convert_custom_gradient"):
+    subgraphs = _extract_subgraphs(graphdef, nodes, library)
+    for _, subgraph in subgraphs.items():
+        nodes = subgraph.rewrite(nodes)
+```
+
+`_extract_subgraphs` builds `_Subgraph` objects. For each `IdentityN`:
+
+- `num_outputs = len(grad_fn.orig_fn_output_specs)` — split point between forward outputs and function inputs in the `IdentityN` inputs list
+- Backward-reachability from `output_node.inputs[:num_outputs]` identifies which nodes form the subgraph
+- `external_captures` = inputs to the subgraph that come from outside it
+- Side-effect nodes (e.g. shape assert nodes from jax2tf) are absorbed into the subgraph
+
+After extraction, overlapping subgraphs are rejected (not yet supported).
+
+`subgraph.rewrite(nodes)` removes the subgraph's individual `_OpNode`s from the main node list and replaces them with the `_Subgraph` object at the position of `output_node`.
+
+### 3. `_Subgraph.__call__` (at run time)
+
+Every time the subgraph is reached in the evaluation loop:
+
+```python
+@jax.custom_gradient
+def fn(*args):
+    # 1. Run the subgraph nodes forward (same as _OpNode evaluation)
+    ...
+    
+    def grad_fn(dy):
+        # 2. Called only during backpropagation
+        # dy has length len(output_node.inputs)
+        # captured_inputs are extra inputs to the gradient function
+        dx = self.grad_fn(*dy, *captures)
+        return dx      # gradients w.r.t. unique_inputs
+    
+    return outputs, grad_fn
+
+outputs = fn(*unboxed_args)
+```
+
+`self.grad_fn` is the `_LibraryFunction` for the gradient function. Calling it triggers `_CachedBuilder`, which triggers `_convert()` on the gradient graph — lazily, on first backprop call.
+
+`@jax.custom_gradient` is re-applied on **every call** to `_Subgraph.__call__` because it's defined inside the method body. This is inefficient; see [design/lazy-custom-gradients.md](../design/lazy-custom-gradients.md).
+
+## Gradient function calling convention
+
+The gradient function (registered via `@tf.custom_gradient`) receives:
+- The upstream gradients w.r.t. each of the `IdentityN` inputs (`dy`, same length as `output_node.inputs`)
+- Any captured inputs that aren't part of the `IdentityN` node (`captures = grad_inputs[len(dy):]`)
+
+It returns one gradient per element of `unique_inputs`.
+
+## Limitations
+
+- Variable assignments inside custom gradient subgraphs are not supported (raises `ValueError`)
+- Overlapping subgraphs (two custom gradients sharing computation) are not supported
+- If the gradient function is not serialized in the SavedModel, `grad_fn` is set to `None` and the subgraph falls back to the standard automatic differentiation path
+
+## Config flags
+
+- `convert_custom_gradient` (default `True`): master switch. If False, `IdentityN` nodes are treated as plain identity ops.
+- `raise_on_prevent_gradient` (default `True`): if a `PreventGradient` op (inserted by `jax2tf.convert(with_gradient=False)`) is hit during differentiation, raise an error.
+
+## Related pages
+
+- [entities/_Subgraph.md](../entities/_Subgraph.md)
+- [entities/_LibraryFunction.md](../entities/_LibraryFunction.md)
+- [concepts/library-functions.md](library-functions.md)
+- [design/lazy-custom-gradients.md](../design/lazy-custom-gradients.md)

--- a/wiki/concepts/graph-evaluation.md
+++ b/wiki/concepts/graph-evaluation.md
@@ -1,0 +1,94 @@
+# Graph Evaluation
+
+*The run-time execution model: a single left-to-right pass over a topologically sorted node list, with reference-counted intermediate storage.*
+
+**Source:** `tf2jax/_src/tf2jax.py:304–340` (toposort), `573–600` (`_EvaluationCache`), `1236–1283` (evaluation loop)
+
+## Topological sort
+
+`_toposort(node_map, end_node_names)` performs a backward-reachability traversal from the output nodes, then reverses to get execution order. Only nodes reachable from outputs are included — dead nodes are silently dropped.
+
+The algorithm works in two passes:
+1. DFS from outputs → count how many times each node is a dependency (`child_counts`)
+2. Process nodes with no remaining children first; decrement counts as parents are visited
+
+```python
+nodes = _toposort(node_map, output_names)   # list[NodeDef]
+nodes = [_OpNode(node, library, node_map) for node in nodes]
+```
+
+The resulting list always has inputs before their consumers.
+
+## `_EvaluationCache`
+
+```python
+class _EvaluationCache:
+    outputs: dict[str, Any]   # node name → value (array or tuple of arrays)
+    _counts: Counter[str]     # reference count per node name
+```
+
+**Initialisation**: pre-populated with `full_inputs` (user args + captured params/constants). Reference counts are set to the number of times each node's output is consumed (by other nodes + by final outputs). Initial inputs get an extra count because they need to survive until used.
+
+**`free_inputs(node)`**: after a node executes, decrement the reference count of each of its inputs. When a count reaches zero, delete the entry from `outputs`. This frees intermediate JAX arrays promptly — important because JAX arrays are immutable references and the Python GC won't free them until all references drop.
+
+## The evaluation loop
+
+```python
+eval_cache = _EvaluationCache(nodes, full_inputs, output_args)
+for node in nodes:
+    if node.name not in eval_cache.outputs:   # skip if already computed (e.g. inputs)
+        collected_inputs = [
+            (v.op_name, eval_cache.outputs[v.op_name]) for v in node.inputs
+        ]
+        sub_rng = rng_keys.pop() if node.require_rng else None
+        eval_cache.outputs[node.name], updated_params = node(
+            collected_inputs, rng=sub_rng)
+        
+        for var_name, var_val in updated_params.items():
+            eval_cache.outputs[var_name] = var_val   # propagate variable updates
+            updated_param_names.add(var_name)
+        
+        eval_cache.free_inputs(node)
+```
+
+### Named-arg protocol
+
+Inputs are passed as `list[(name, value)]` rather than just values. `_OpNode.__call__` calls `_unbox_named_args(named_args, self.inputs)` which:
+1. Validates that the names match the expected edge op names (defensive consistency check)
+2. Extracts indexed outputs: if a node returns a tuple, `arg[inp.idx]` picks the right element
+
+**Why the names are included:** The protocol predates the current strict topological sort. The name check was a defensive guard to catch bugs where the wrong node's output was collected for a given input edge — possible when the collection code was less structured. Today, topological sort + the `[v.op_name for v in node.inputs]` collection loop guarantees correctness, making the name validation redundant.
+
+**Why `(name, value)` tuples rather than just a dict lookup:** The current loop builds `collected_inputs` as an ordered list that matches `node.inputs` positionally, then `_unbox_named_args` validates and strips names. Passing `eval_cache.outputs` directly and indexing by `inp.op_name` would be equivalent and simpler.
+
+> **Refactoring note:** See [design/refactoring-recommendations.md](../design/refactoring-recommendations.md) item 6.
+
+### Variable assignment ops
+
+`AssignVariableOp`, `AssignAddVariableOp`, `AssignSubVariableOp` return updated values and are listed in `_TF_ASSIGN_OPS`. When `_OpNode.__call__` detects these, it includes them in `updated_params`. The loop then writes the updated value back into `eval_cache.outputs` under the *variable node name*, so subsequent reads of that variable see the updated value.
+
+### RNG distribution
+
+Random ops (`RandomStandardNormal`, `RandomUniform`, `RandomUniformInt`) need a JAX PRNGKey. If any are present, `jax.random.split(rng, num_rng_required)` is called once and keys are distributed one-per-random-op. The count `num_rng_required` is computed at build time.
+
+## Control inputs
+
+Some edges are control dependencies (`^NodeName` in the proto) rather than data edges. These are stored separately as `node.control_inputs`. The evaluation loop validates that control dependencies have been executed (their names are in `eval_cache.outputs`) but does not pass their values to the node.
+
+## Output reconstruction
+
+After the loop:
+
+```python
+tensor_outputs = tuple([eval_cache.outputs[k.op_name] for k in output_args])
+tensor_outputs = [v for v in tensor_outputs if v is not _EMPTY_RETURN_VALUE]
+```
+
+`_EMPTY_RETURN_VALUE` is used for ops with no meaningful return (e.g. `NoOp`). Non-tensor outputs (specs that passed through unchanged) are reinserted, and the whole is unflattened into `structured_outputs` shape.
+
+## Related pages
+
+- [concepts/conversion-phases.md](conversion-phases.md)
+- [entities/_OpNode.md](../entities/_OpNode.md)
+- [entities/_Subgraph.md](../entities/_Subgraph.md)
+- [concepts/variable-semantics.md](variable-semantics.md)

--- a/wiki/concepts/jax2tf-roundtrip.md
+++ b/wiki/concepts/jax2tf-roundtrip.md
@@ -1,0 +1,69 @@
+# jax2tf Round-Trip
+
+*tf2jax can convert functions that were themselves produced by `jax2tf.convert`, enabling JAX→TF→JAX round-trips. This use case drives several otherwise-puzzling design choices.*
+
+**Source:** `tf2jax/_src/tf2jax.py:877–899` (relu heuristic), `ops.py:2724–2763` (cumulative reduction heuristic), `numpy_compat.py:71–89` (poly dim handling)
+
+## The round-trip pattern
+
+```python
+# JAX → TF
+tf_fn = jax2tf.convert(jax_model, polymorphic_shapes=["(b, d)"])
+
+# TF → JAX (via tf2jax)
+jax_fn, params = tf2jax.convert(tf_fn, tf.TensorSpec((None, 4)))
+```
+
+This is used to:
+- Load JAX models serialized as TF SavedModels into a JAX environment
+- Fine-tune or compose JAX models that went through a TF checkpoint
+- Test round-trip numerical fidelity
+
+## What jax2tf does to the graph
+
+`jax2tf.convert` produces TF graphs that contain artifacts from the lowering process. These are patterns that tf2jax must recognise and handle correctly:
+
+### 1. `max(x, 0)` instead of `relu`
+
+jax2tf lowers `jax.nn.relu` as `tf.maximum(x, tf.cast(0, x.dtype))` rather than `tf.nn.relu`. The resulting graph has a `Maximum` node fed by a `Cast`-of-`Const` node. If tf2jax naively converts this, it creates a JAX graph that does the same thing — but loses the opportunity to use `jax.nn.relu` directly, which is more gradient-friendly.
+
+`_infer_relu_from_jax2tf` detects this pattern. See [entities/jax2tf-heuristics.md](../entities/jax2tf-heuristics.md).
+
+### 2. `reduce_window` instead of `cumsum`/`cumprod`
+
+jax2tf lowers `jax.lax.cumsum` as `jax.lax.reduce_window` (a sliding-window reduction). The XlaReduceWindow op that results is functionally correct but opaque — JAX won't recognise it as a cumulative reduction for gradient purposes.
+
+`infer_cumulative_reduction_from_jax2tf` detects this pattern inside `_XlaReduceWindow`. See [entities/jax2tf-heuristics.md](../entities/jax2tf-heuristics.md).
+
+### 3. Polymorphic shapes
+
+`jax2tf.convert` with `polymorphic_shapes` produces graphs where some dimensions are symbolic (`_DimPolynomial`) rather than concrete integers. tf2jax must propagate these through shape computations rather than trying to evaluate them as NumPy scalars.
+
+The `numpy_compat` layer handles this: `is_poly_dim(x)` detects symbolic dimensions and routes to `jnp` instead of `np`. `broadcast_to` and `_fix_jax_poly_shape` have explicit poly-dim handling. See [concepts/numpy-compat.md](numpy-compat.md).
+
+### 4. `PreventGradient` ops
+
+`jax2tf.convert(with_gradient=False)` inserts `tf.raw_ops.PreventGradient` ops to block differentiation of the converted function. If the converted function is later differentiated in JAX, tf2jax raises an error unless `raise_on_prevent_gradient=False` is set in config.
+
+### 5. Shape assertion nodes
+
+jax2tf inserts shape check assert nodes as side effects of certain operations. `_extract_subgraphs` explicitly handles these: they are detected as "side effect nodes" (nodes that depend on the subgraph but don't feed into its outputs) and absorbed into the subgraph rather than left dangling in the main graph.
+
+### 6. `XlaCallModule` (native serialization)
+
+Newer versions of jax2tf with `native_serialization=True` produce `XlaCallModule` ops containing StableHLO bytecode instead of a full TF graph. These require separate handling in `tf2jax/experimental/ops.py`. Platform-specific — a module lowered for TPU may not run on CPU.
+
+## Config flags specific to this use case
+
+| Flag | Default | Purpose |
+|------|---------|---------|
+| `infer_relu_from_jax2tf` | `True` | Detect `max(x,0)` and replace with `relu` |
+| `infer_cumulative_reduction_from_jax2tf` | `True` | Detect `reduce_window` cumsum/cumprod patterns |
+| `raise_on_prevent_gradient` | `True` | Error on differentiation barriers |
+| `xlacallmodule_strict_checks` | `True` | Validate platform for native serialization |
+
+## Related pages
+
+- [entities/jax2tf-heuristics.md](../entities/jax2tf-heuristics.md)
+- [concepts/numpy-compat.md](numpy-compat.md)
+- [concepts/custom-gradients.md](custom-gradients.md)

--- a/wiki/concepts/library-functions.md
+++ b/wiki/concepts/library-functions.md
@@ -1,0 +1,121 @@
+# Library Functions
+
+*TF's `FunctionDefLibrary` stores reusable sub-functions (control flow bodies, gradient functions). tf2jax converts these recursively and caches each one.*
+
+**Source:** `tf2jax/_src/tf2jax.py:167–218` (`_CachedBuilder`, `_LibraryFunction`), `1288–1374` (`_convert_library_function`), `904–926` (`_get_function_protos`)
+
+## Background: what is `FunctionDefLibrary`?
+
+Every `tf.GraphDef` has an embedded `library` of `FunctionDef` protos. These are the inner functions used by:
+- `tf.cond`, `tf.switch_case` → each branch is a library function
+- `tf.while_loop` → body and condition are library functions
+- `tf.map_fn` → the mapped function is a library function
+- `@tf.custom_gradient` → the gradient function is a library function
+
+Library functions can reference each other (e.g. a while body may call a helper). tf2jax processes them in dependency order.
+
+## `_get_function_protos`
+
+```python
+def _get_function_protos(graphdef) -> Iterator[(str, FunctionDef)]:
+```
+
+A recursive generator that yields `(name, proto)` pairs in dependency order — a function's callees are yielded before the function itself. This ensures the `library` dict is always populated before any function that references it.
+
+## `_convert_library_function`
+
+Converts a `FunctionDef` proto into a `_LibraryFunction`. Steps:
+
+1. **Synthesise a `_GraphDef`** from the `FunctionDef`:
+   - Each `input_arg` becomes a `Placeholder` node
+   - Each `node_def` is included as-is
+   - Each `output_arg` becomes an `Identity` node
+
+2. **Handle `VarHandleOp`** — variables embedded in library functions (from checkpoints) are surfaced as additional positional parameters.
+
+3. **Determine `require_rng`** — check if any node op is in `_TF_RANDOM_OPS` or if any inner function requires RNG.
+
+4. **Create a `_CachedBuilder`** that lazily calls `_convert()` on the synthesised `_GraphDef`.
+
+## `_CachedBuilder`
+
+```python
+class _CachedBuilder:
+    def __init__(self, builder_fn, cached_configs):
+        self._builder_fn = functools.lru_cache(builder_fn)
+        self._cached_configs = cached_configs
+    
+    def __call__(self):
+        with config.override_configs(self._cached_configs):
+            return self._builder_fn()
+```
+
+**Purpose:** call-once semantics with frozen config. `functools.lru_cache` on a zero-argument function means the builder runs exactly once; subsequent calls return the cached result. The config at build time is captured via `config.copy_config()` and restored during execution, so library functions compiled under one config setting don't pick up later changes.
+
+> **Clarity note:** Using `lru_cache` on a zero-arg function to get "call once" semantics is idiomatic but unintuitive. A lazy-init pattern (`if self._result is None: ...`) would be more explicit.
+
+## `_LibraryFunction`
+
+```python
+class _LibraryFunction(NamedTuple):
+    fn_builder: _CachedBuilder
+    require_rng: bool
+    input_specs: Optional[Tuple[tf.TensorSpec, ...]]
+    output_specs: Optional[Tuple[tf.TensorSpec, ...]]
+    orig_fn_output_specs: Optional[Tuple[tf.TensorSpec, ...]]  # gradient functions only
+    output_is_input: Optional[Tuple[bool]]
+    variable_input_specs: Optional[Tuple[tf.TensorSpec, ...]]
+    
+    @property
+    def fn(self): fn, _ = self.fn_builder(); return fn
+    @property
+    def params(self): _, p = self.fn_builder(); return p
+    
+    def __call__(self, *args, **kwargs):
+        if self.params:
+            return self.fn(self.params, *args, **kwargs)
+        else:
+            return self.fn({}, *args, **kwargs)[0]
+```
+
+When `__call__` is first invoked, `fn_builder()` triggers the lazy `_convert()` and caches the result. The `params` check handles the rare case where a library function captures its own variables (e.g. from a checkpoint-embedded `VarHandleOp`).
+
+## Usage in `_OpNode` (higher-order ops)
+
+Higher-order function ops (`Case`, `While`, `If`, `MapFn`) implement `_HigherOrderFunction`, which has:
+
+```python
+def get_inner_functions(self, library_functions):
+    return {k: library_functions[v] for k, v in self.inner_fn_names.items()}
+```
+
+`_OpNode.__init__` calls this and stores the result in `self.inner_fns`. At run time, inner functions are passed as keyword arguments to the op's `jax_func`:
+
+```python
+outputs = self.jax_func(*unboxed_args, **self.inner_fns)
+```
+
+The op's factory then uses them:
+
+```python
+@register_operation("While")
+def _while(proto):
+    cond_fn_name = proto.attr["cond"].func.name
+    body_fn_name = proto.attr["body"].func.name
+    
+    def _func(*args, cond_fn=None, body_fn=None):
+        return jax.lax.while_loop(cond_fn, body_fn, args)
+    
+    return _While(dict(cond_fn=cond_fn_name, body_fn=body_fn_name))
+```
+
+## Name collision note
+
+`ops.py` defines a separate `_LibraryFunction` as a `Protocol` used for type-checking `variable_input_specs` access in `_HigherOrderFunction.get_additional_inputs`. This is a different concept from the `_LibraryFunction` `NamedTuple` in `tf2jax.py`. The shared name is confusing — the Protocol one describes "something that has `variable_input_specs`".
+
+## Related pages
+
+- [entities/_LibraryFunction.md](../entities/_LibraryFunction.md)
+- [concepts/custom-gradients.md](custom-gradients.md)
+- [entities/_HigherOrderFunction.md](../entities/_HigherOrderFunction.md)
+- [concepts/conversion-phases.md](conversion-phases.md)

--- a/wiki/concepts/numpy-compat.md
+++ b/wiki/concepts/numpy-compat.md
@@ -1,0 +1,91 @@
+# NumPy Compatibility Layer
+
+*`numpy_compat` (`anp`) provides a dispatch layer that routes to `np` or `jnp` based on input types, enabling constant folding at graph build time.*
+
+**Source:** `tf2jax/_src/numpy_compat.py`
+
+## Why this exists
+
+During graph conversion, some computations run at **build time** with Python scalars and NumPy arrays (e.g. shape computations, `Const` node evaluation, dtype resolution). Others run at **run time** with JAX arrays inside JIT-compiled functions.
+
+If all ops always use `jnp`, then build-time computations become JAX operations, which: (a) can't be used with Python scalars cleanly, (b) create unnecessary JAX traced values during conversion, and (c) break for symbolic dimensions.
+
+The `anp` layer selects the right backend automatically.
+
+## The dispatch mechanism
+
+```python
+_NP_LIKES = (np.ndarray, np.number, np.bool_, bool, int, float, complex)
+
+def _is_np(x) -> bool:
+    # Special case: 1-D np.array containing poly dims is NOT np-like
+    if isinstance(x, np.ndarray) and x.ndim == 1 and any(map(is_poly_dim, x)):
+        return False
+    return isinstance(x, _NP_LIKES) or is_poly_dim(x)
+
+def _get_np(*args):
+    """Returns np if all args are numpy-like, else jnp."""
+    return np if all(map(_is_np, args)) else jnp
+```
+
+Simple ops are then one-liners:
+
+```python
+add = lambda x, y: _get_np(x, y).add(x, y)
+multiply = lambda x, y: _get_np(x, y).multiply(x, y)
+```
+
+## Polymorphic dimension handling
+
+`is_poly_dim(x)` detects symbolic dimensions from `jax2tf` (type `_DimPolynomial`). These are neither NumPy arrays nor JAX arrays — they represent symbolic shape values. The compatibility layer routes them to JAX:
+
+```python
+def is_poly_dim(x) -> bool:
+    if jax.__version_info__ >= (0, 4, 30):
+        from jax import export
+        return export.is_symbolic_dim(x)
+    # Fallback: if operator.index() raises TypeError, it's symbolic
+    try:
+        operator.index(x)
+    except TypeError:
+        return True
+    return False
+```
+
+`broadcast_to` has explicit poly-dim handling:
+
+```python
+def broadcast_to(arr, shape):
+    np_ = jnp if any([is_poly_dim(x) for x in shape]) else _get_np(arr)
+    return np_.broadcast_to(arr, shape)
+```
+
+## Dtype conversion
+
+Two parallel tables map `tf.DType` → NumPy/JAX dtypes:
+
+```python
+tf_to_np_dtypes  = {tf.float32: np.float32, tf.bool: np.bool_, ...}
+tf_to_jnp_dtypes = {tf.float32: jnp.float32, tf.bool: jnp.bool_, ...}
+```
+
+Selected via `_get_dtypes(*args)` which delegates to `_get_np`. Used by `asarray`, `arange`, `full`, `empty`.
+
+> **Simplification opportunity:** the two tables are structurally identical (same 14 keys). A single table of `(np_dtype, jnp_dtype)` tuples would make divergences explicit. Most entries are identical objects (`np.float32 is jnp.float32`).
+
+## Ops that need special handling
+
+**`gather`** — NumPy and JAX have fundamentally different `take` semantics for batch dims; both implementations are written separately.
+
+**`scatter_nd`** — NumPy uses in-place indexing (`res[key] = updates`); JAX uses `.at[key].set(updates)`.
+
+**`invert_permutation`** — NumPy uses index assignment; JAX uses `.at[arr].set(...)`.
+
+**`squeeze`** — TF squeezes all dims when `axis=()`, but NumPy/JAX squeeze none. Normalised to `None`.
+
+**`divide`** — NumPy `divide` on integer types is true divide; the result dtype must be forced explicitly.
+
+## Related pages
+
+- [concepts/op-registry.md](op-registry.md)
+- [concepts/conversion-phases.md](conversion-phases.md)

--- a/wiki/concepts/op-registry.md
+++ b/wiki/concepts/op-registry.md
@@ -1,0 +1,126 @@
+# Op Registry
+
+*The op registry maps TensorFlow op names to JAX implementations via a two-level factory pattern.*
+
+**Source:** `tf2jax/_src/ops.py:68–237`
+
+## The registry
+
+```python
+_jax_ops: dict[str, Callable[[NodeDef], Callable[..., Any]]]
+```
+
+Keys are TensorFlow op names (e.g. `"Conv2D"`, `"MatMul"`, `"Cast"`). Values are **factory functions** — callables that take a `NodeDef` proto and return the actual JAX operation.
+
+This two-level indirection is the core pattern of `ops.py`:
+
+```
+op name  →  factory(proto)  →  jax_callable(*arrays)
+```
+
+The factory runs **once at build time**, reading static attributes from the proto (strides, padding, dtype, axis, etc.) and closing over them. The returned `jax_callable` runs **at every execution**.
+
+## Simple ops: `_get_jax_op`
+
+For ops with no interesting runtime behaviour, `_get_jax_op` creates a factory that just validates attributes and returns a fixed JAX function:
+
+```python
+def _get_jax_op(jax_op, expected_attrs):
+    def wrapped(proto):
+        _check_attrs(proto, expected_attrs)  # validates no unknown attrs
+        return jax_op                        # returns the JAX fn directly
+    return wrapped
+
+# Usage:
+"Add": _get_jax_op(anp.add, {"T"}),
+"MatMul": _get_jax_op(jnp.matmul, {"T", "transpose_a", "transpose_b"}),
+```
+
+~120 ops are registered this way.
+
+## Complex ops: custom factories
+
+For ops with meaningful static attributes, the factory reads them and closes over them:
+
+```python
+@register_operation("Conv2D")
+def _conv2d(proto):
+    padding = str(proto.attr["padding"].s, "utf-8")
+    strides = tuple(proto.attr["strides"].list.i)
+    data_format = str(proto.attr["data_format"].s, "utf-8")
+    dimension_numbers = ("NHWC", "HWIO", "NHWC") if data_format == "NHWC" else ...
+    strides = xla_utils.get_conv_sequence(strides, ...)
+
+    def _func(lhs, rhs):                    # ← this is what gets called at run time
+        feature_group_count = lhs.shape[...] // rhs.shape[...]
+        return jax.lax.conv_general_dilated(lhs, rhs, strides, padding,
+                                            dimension_numbers, ...)
+    return _func
+```
+
+The factory pattern means that `padding`, `strides`, and `dimension_numbers` are Python values baked into the closure — they never touch the JAX tracing.
+
+## Registration
+
+```python
+def register_operation(op_name):
+    return functools.partial(_register, op_name=op_name)
+
+def _register(func, op_name):
+    if op_name in _jax_ops and _jax_ops[op_name] != func:
+        raise ValueError(f"{op_name} already registered as {_jax_ops[op_name]}")
+    _jax_ops[op_name] = func
+    return func
+```
+
+`register_operation` is a decorator. Duplicate registration of different functions raises; identical re-registration (e.g. from module reloads) is silently accepted.
+
+Multiple op names can share one factory:
+
+```python
+@register_operation("FusedBatchNormV3")
+@register_operation("FusedBatchNormV2")
+@register_operation("FusedBatchNorm")
+def _fused_batch_norm(proto): ...
+```
+
+## Dispatch
+
+```python
+def get_parser(op_name: str) -> Callable:
+    return _jax_ops[op_name]   # KeyError if unsupported
+```
+
+Called in `_OpNode.__init__`:
+
+```python
+self.jax_func = ops.get_parser(proto.op)(proto)
+#                               ↑ factory  ↑ invoke factory → get jax callable
+```
+
+Unsupported ops raise `ValueError` early (in `_convert`, before any execution), via `ops.get_unsupported_operations`.
+
+## Higher-order ops
+
+Control flow ops (`Case`, `If`, `While`, `MapFn`) implement the `_HigherOrderFunction` dataclass protocol rather than returning a plain callable. See [entities/_HigherOrderFunction.md](../entities/_HigherOrderFunction.md).
+
+## The `numpy_compat` layer
+
+Many simple ops are registered against `anp.xxx` rather than `jnp.xxx`. `anp` is `numpy_compat`, a dispatch layer that routes to `np` when all inputs are static (NumPy arrays) and to `jnp` otherwise. This is necessary because many graph operations (shape computations, constant folding) are evaluated with NumPy arrays at build time. See [concepts/numpy-compat.md](numpy-compat.md).
+
+## Adding a new op
+
+```python
+@register_operation("MyNewOp")
+def _my_new_op(proto):
+    _check_attrs(proto, {"T", "some_attr"})
+    some_attr = proto.attr["some_attr"].i
+    return lambda x: jnp.something(x, some_attr)
+```
+
+## Related pages
+
+- [entities/_OpNode.md](../entities/_OpNode.md)
+- [entities/_HigherOrderFunction.md](../entities/_HigherOrderFunction.md)
+- [concepts/numpy-compat.md](numpy-compat.md)
+- [overview.md](../overview.md)

--- a/wiki/concepts/variable-semantics.md
+++ b/wiki/concepts/variable-semantics.md
@@ -1,0 +1,94 @@
+# Variable Semantics
+
+*TF's mutable variables are mapped to JAX's functional parameter pattern: variables enter as explicit dict arguments, updated values exit alongside outputs.*
+
+**Source:** `tf2jax/_src/tf2jax.py:343–367` (`Variable`), `1070–1125` (extraction), `1273–1283` (return)
+
+## The problem
+
+TF `tf.Variable` objects are mutable state. JAX arrays are immutable. tf2jax bridges this by treating variables as function parameters that must be explicitly threaded through calls.
+
+## `Variable` class
+
+```python
+class Variable(np.ndarray):
+    trainable: bool
+    name: str
+```
+
+A thin NumPy subclass that preserves trainability and name metadata. Variables live in the `params` dict returned by `convert()`. They are NumPy arrays — not JAX arrays — so they can be inspected, sliced, and modified outside of JAX transforms.
+
+## Extraction at build time
+
+During `_convert()`:
+
+1. `variable_map: dict[str, tf.Variable]` is built from `concrete_func.variables` — maps the node name of the variable's placeholder in the graph to the live TF Variable.
+
+2. Variables are uniquified by name (duplicates get `_1`, `_2` suffixes).
+
+3. Each variable is evaluated eagerly: `Variable(v.numpy(), v.trainable, v.name)`.
+
+4. Two bidirectional indexes are built:
+   - `var_by_node: dict[str, str]` — graph node name → `params` dict key
+   - `node_by_var: dict[str, str]` — `params` dict key → graph node name
+
+## At run time: reading variables
+
+Variables flow in as part of `params`. Inside `jax_func`:
+
+```python
+all_params = dict(**params, **constants)
+full_inputs = inputs + tuple([all_params[var_by_node.get(v, v)] for v in captured_input_names])
+```
+
+`captured_input_names` is the list of graph node names for variable/constant captures. Each is looked up via `var_by_node` to find the key in `all_params`, and the value is prepended to the graph inputs.
+
+## At run time: writing variables
+
+Assign ops (`AssignVariableOp`, `AssignAddVariableOp`, `AssignSubVariableOp`) are registered in `_TF_ASSIGN_OPS`. Their JAX implementations are:
+
+```python
+"AssignVariableOp":    lambda var, x: x,
+"AssignAddVariableOp": jnp.add,
+"AssignSubVariableOp": jnp.subtract,
+```
+
+When `_OpNode.__call__` detects one of these, it returns the result as `updated_params`. The evaluation loop writes this back into `eval_cache.outputs` under the variable's node name, so any subsequent reads of that variable in the same call see the updated value.
+
+## Return: new params
+
+At the end of `jax_func`:
+
+```python
+new_params = {
+    var_name: eval_cache.outputs[node_by_var[var_name]]
+    for var_name in params.keys()
+}
+return collected_outputs, new_params
+```
+
+`node_by_var` maps back from the `params` key to the node name whose output in `eval_cache` holds the current (possibly updated) value. Even if a variable was never assigned in this call, its original value is still in `eval_cache` and is returned unchanged.
+
+## Usage pattern
+
+```python
+jax_fn, params = tf2jax.convert(tf_model, *sample_inputs)
+
+# Inference (params unchanged)
+outputs, params = jax_fn(params, *inputs)
+
+# Training (params updated by assign ops inside the model)
+outputs, params = jax_fn(params, *inputs)
+# ^ params now reflects any variable updates the model made
+```
+
+## Gotcha: `skip_variables_evaluation_inside_tf_tracing`
+
+When `convert()` is called inside a `tf.function` (e.g. when exporting a JAX model back to TF via SavedModel), `tf.inside_function()` returns True and `v.numpy()` cannot be called. Setting `skip_variables_evaluation_inside_tf_tracing=True` in config skips variable evaluation, returning an empty `params` dict. The variables must be supplied by another means.
+
+## Related pages
+
+- [overview.md](../overview.md)
+- [concepts/graph-evaluation.md](graph-evaluation.md)
+- [entities/convert-api.md](../entities/convert-api.md)
+- [entities/Variable.md](../entities/Variable.md)

--- a/wiki/design/lazy-custom-gradients.md
+++ b/wiki/design/lazy-custom-gradients.md
@@ -1,0 +1,141 @@
+# Lazy Custom Gradient Evaluation
+
+*Design for deferring gradient function setup to the first backward pass, avoiding TF tracing and custom_gradient overhead on forward-only calls.*
+
+**Status:** Proposed, not yet implemented. Discussed April 2026.
+
+---
+
+## The problem
+
+Currently, on every call to `convert()`:
+
+1. `_convert_all_gradient_functions(graph, library)` is called **eagerly**, which for each `@tf.custom_gradient` site:
+   - Looks up the gradient function in TF's registry
+   - Calls `get_concrete_function(*input_specs)` → **full TF graph trace**
+   - Extracts metadata from the concrete function
+
+2. In `_Subgraph.__call__`, `@jax.custom_gradient` is **re-applied on every forward call**, creating a new decorated function each time.
+
+A model used purely for inference pays the full cost of gradient function setup.
+
+**What is already lazy:**
+- The JAX conversion of the gradient function body — `_CachedBuilder` defers `_convert()` to first `fn_builder()` call, which only occurs inside `grad_fn`, which only runs during backpropagation.
+
+**What is not lazy:**
+- TF tracing of the gradient function (`get_concrete_function`) — happens at `convert()` time
+- `_extract_subgraphs` reads `grad_fn.orig_fn_output_specs` and `grad_fn.input_specs` — requires the TF trace
+- `@jax.custom_gradient` re-decoration — happens on every forward call
+
+---
+
+## The circular dependency
+
+`_extract_subgraphs` needs from `grad_fn`:
+
+- `grad_fn.orig_fn_output_specs` → `num_outputs`: splits `IdentityN.inputs[:num_outputs]` (forward outputs) from `[num_outputs:]` (function inputs)
+- `grad_fn.input_specs[len(node.input):]` → `captured_inputs`: gradient function inputs beyond the `IdentityN` node
+
+Both require TF tracing. But `num_outputs` can be derived from **graph topology alone**:
+
+> The `IdentityN` inputs that are produced by nodes *inside the subgraph* are the forward outputs. Those produced by nodes *outside* are the function inputs.
+
+This is computable from `subgraph_node_names` and the graph structure — no gradient function needed.
+
+`captured_inputs` is only needed for the **backward pass** and can be deferred.
+
+---
+
+## The design
+
+### Step 1: Remove `_convert_all_gradient_functions` from `convert()`
+
+Do not build `_LibraryFunction` for gradient functions at conversion time. Instead, store a lazy reference in each `_Subgraph`.
+
+### Step 2: Compute `num_outputs` from graph topology in `_extract_subgraphs`
+
+```python
+# Replace: num_outputs = len(grad_fn.orig_fn_output_specs)
+# With:
+num_outputs = sum(
+    1 for inp in output_node.inputs
+    if inp.op_name in subgraph_node_names
+)
+```
+
+`_extract_subgraphs` no longer needs the pre-built `grad_fn`. `_Subgraph` stores `grad_fn_name`, a reference to the TF graph, and a lazy builder instead of a `_LibraryFunction`.
+
+### Step 3: Switch `_Subgraph.__call__` to `jax.custom_vjp` with lazy backward
+
+```python
+class _Subgraph:
+    _vjp_fn = None   # built once, cached on instance
+
+    def __call__(self, named_args, *, rng):
+        if self._vjp_fn is None:
+            self._vjp_fn = self._build_vjp_fn()
+        ...
+        return self._vjp_fn(*unboxed_args), {}
+
+    def _build_vjp_fn(self):
+        subgraph = self.subgraph
+        output_node = self.output_node
+
+        @jax.custom_vjp
+        def fn(*args):
+            return _run_subgraph_forward(subgraph, output_node, args)
+
+        def fn_fwd(*args):
+            out = fn(*args)
+            return out, args   # save inputs as residuals
+
+        def fn_bwd(residuals, g):
+            # First time here → trigger TF tracing + JAX conversion
+            grad_fn = self._get_or_build_grad_fn()
+            captured = self._extract_captures(residuals, grad_fn)
+            return grad_fn(*g, *captured)
+
+        fn.defvjp(fn_fwd, fn_bwd)
+        return fn
+
+    def _get_or_build_grad_fn(self):
+        if self._grad_fn is None:
+            _convert_gradient_function(self._proto, self._graph, self._library)
+            self._grad_fn = self._library[self._grad_fn_name]
+        return self._grad_fn
+```
+
+### Key properties
+
+- **Forward pass only**: `fn_bwd` never runs, no TF tracing, no `_CachedBuilder` materialisation
+- **First backward**: `fn_bwd` runs → TF tracing triggered → `_CachedBuilder` triggered → gradient function compiled to JAX → result cached
+- **Subsequent backwards**: `self._grad_fn` is populated → direct call, no rebuilding
+- **`_vjp_fn` built once**: `@jax.custom_vjp` decoration happens once per `_Subgraph` instance, not per call
+
+### Residuals and `captured_inputs`
+
+`fn_fwd` saves `args` (the `unique_inputs` of the subgraph) as residuals. These are the inputs to the subgraph, which includes function inputs and external captures. In `fn_bwd`, `grad_fn.input_specs[len(g):]` (the additional captures) can be looked up from `residuals` because they are a subset of `unique_inputs`.
+
+If `captured_inputs` are not a subset of `unique_inputs` (edge case: captures from outer scopes not part of the subgraph's explicit inputs), they may need to be passed as `nondiff_argnums` in `custom_vjp` or stored as a JAX-untraced closure.
+
+---
+
+## Summary of changes
+
+| Location | Before | After |
+|----------|--------|-------|
+| `convert()` | calls `_convert_all_gradient_functions` | removed |
+| `_extract_subgraphs` | reads `grad_fn.orig_fn_output_specs`, `grad_fn.input_specs` | uses graph topology for `num_outputs`; defers captures |
+| `_Subgraph.__init__` | stores pre-built `_LibraryFunction grad_fn` | stores lazy builder + TF graph reference |
+| `_Subgraph.__call__` | re-applies `@jax.custom_gradient` on every call | builds `custom_vjp` function once, cached on instance |
+| First forward call | TF already traced, setup done | nothing extra |
+| First backward call | JAX conversion of grad fn (already lazy) | TF tracing + JAX conversion both happen here |
+
+**Net result:** A model used purely for inference pays zero cost for custom gradient support.
+
+## Related pages
+
+- [concepts/custom-gradients.md](../concepts/custom-gradients.md)
+- [entities/_Subgraph.md](../entities/_Subgraph.md)
+- [entities/_LibraryFunction.md](../entities/_LibraryFunction.md)
+- [design/refactoring-recommendations.md](refactoring-recommendations.md)

--- a/wiki/design/refactoring-recommendations.md
+++ b/wiki/design/refactoring-recommendations.md
@@ -1,0 +1,122 @@
+# Refactoring Recommendations
+
+*Structural changes that would reduce cognitive load for readers and developers. Discussed and agreed upon in April 2026.*
+
+**Status:** Proposed, not yet implemented.
+
+---
+
+## 1. Replace the `jax_func` closure with a `_CompiledGraph` class
+
+**The problem:** `_convert()` defines a `jax_func` closure that implicitly captures 12 build-time variables. Readers must mentally inventory all 12 to understand what the function does. The data model is invisible.
+
+**The fix:** A class whose `__init__` accepts the 12 variables as named parameters and stores them as typed `self.` fields, with `__call__` containing the current closure body.
+
+```python
+class _CompiledGraph:
+    def __init__(self, nodes, input_names, input_path_to_specs,
+                 output_args, structured_outputs, flat_output_specs,
+                 captured_input_names, constants, var_by_node, node_by_var,
+                 signature, num_rng_required):
+        ...
+    
+    def __call__(self, params, *args, rng=None, **kwargs):
+        ...  # current jax_func body, unchanged
+```
+
+**Benefits:**
+- Build time (`__init__`) and run time (`__call__`) are explicitly separated
+- All dependencies are declared and typed, not inferred from captures
+- The class is independently testable
+- `_convert()` becomes shorter and more readable
+
+---
+
+## 2. Define a `_GraphNode` Protocol
+
+**The problem:** After `_extract_subgraphs`, the node list is silently `list[_OpNode | _Subgraph]`. Both implement the same interface but there is no formal declaration. Readers don't know that `node` can be a `_Subgraph`.
+
+**The fix:**
+
+```python
+class _GraphNode(Protocol):
+    name: str
+    inputs: Tuple[_TensorEdge, ...]
+    control_inputs: Tuple[_TensorEdge, ...]
+    require_rng: bool
+    def __call__(self, named_args: Sequence[Tuple[str, Any]], *, rng) -> ...: ...
+```
+
+Type the node list as `list[_GraphNode]` everywhere.
+
+---
+
+## 3. Extract custom gradient code to its own module
+
+**The problem:** ~350 lines of custom gradient machinery (`_filter_nodes`, `_contains_custom_gradient`, `_get_consumers_and_producers_fns`, `_extract_subgraphs`, `_convert_all_gradient_functions`, `_convert_gradient_function`, `_Subgraph`) are interspersed throughout `tf2jax.py`. When reading `_convert`, it's unclear which parts are core and which are the custom gradient extension.
+
+**The fix:** Move to `tf2jax/_src/_custom_gradient.py`. The hook in `_convert` stays as-is — one import, one call. Core conversion becomes readable without knowing anything about custom gradients.
+
+---
+
+## 4. Resolve the `_LibraryFunction` name collision
+
+**The problem:** `_LibraryFunction` exists in both `tf2jax.py` (a concrete `NamedTuple` wrapping a built JAX function) and `ops.py` (a `Protocol` for type-checking `variable_input_specs` access). Same name, different concepts.
+
+**The fix:** Rename the `ops.py` Protocol to `_HasVariableInputSpecs`. Or inline the single attribute access and delete the Protocol entirely.
+
+---
+
+## 5. Normalise to `_GraphDef` before `_convert`
+
+**The problem:** `_convert` accepts `Union[tf.compat.v1.GraphDef, _GraphDef]`. The union propagates through the whole function. The `hasattr(graphdef, "library")` check distinguishes the two. Readers must know both representations exist.
+
+**The fix:** Normalise to `_GraphDef` before calling `_convert`. `_convert_library_function` already assembles `_GraphDef` from `FunctionDef`. Do the same for top-level `GraphDef`s so `_convert` always receives one type.
+
+---
+
+## 6. Pass `outputs_dict` directly to nodes (remove `named_args` ceremony)
+
+**The problem:** The evaluation loop wraps values as `list[(name, value)]` → `_unbox_named_args` validates names and strips them → plain values reach the JAX callable. The name-checking is defensive but redundant (topological sort guarantees correctness).
+
+**The fix:**
+
+```python
+# In _OpNode.__call__(self, outputs_dict, *, rng):
+args = tuple(
+    outputs_dict[inp.op_name][inp.idx]
+    if isinstance(outputs_dict[inp.op_name], (list, tuple))
+    else outputs_dict[inp.op_name]
+    for inp in self.inputs
+)
+```
+
+Removes `_unbox_named_args` entirely and makes the data flow — "look up each input by name" — directly visible.
+
+---
+
+## 7. Drop TF1 Session code path
+
+**The problem:** Lines `1101–1113` contain a dead `else: # We are in TF1 mode` branch using `tf.compat.v1.Session`. In TF2, `tf.executing_eagerly()` is always True, so this is unreachable.
+
+**The fix:** Delete the `else` branch and remove the associated `tf.compat.v1` imports.
+
+---
+
+## Priority order
+
+| # | Change | Risk | Leverage |
+|---|--------|------|---------|
+| 3 | Extract custom gradient module | Medium | Highest — unblocks reading core |
+| 1 | `_CompiledGraph` class | Medium | High — makes data model visible |
+| 2 | `_GraphNode` Protocol | Low | Medium — documents existing contract |
+| 7 | Drop TF1 code | Low | Low — dead code removal |
+| 4 | Rename `_LibraryFunction` collision | Low | Low — terminology |
+| 5 | Normalise to `_GraphDef` | Medium | Medium — removes Union type |
+| 6 | Remove `named_args` ceremony | Low | Medium — evaluation loop clarity |
+
+## Related pages
+
+- [design/lazy-custom-gradients.md](lazy-custom-gradients.md)
+- [concepts/conversion-phases.md](../concepts/conversion-phases.md)
+- [concepts/custom-gradients.md](../concepts/custom-gradients.md)

--- a/wiki/entities/Variable.md
+++ b/wiki/entities/Variable.md
@@ -1,0 +1,56 @@
+# `Variable`
+
+*NumPy `ndarray` subclass that carries TF variable metadata (name, trainability) through the conversion boundary.*
+
+**Source:** `tf2jax/_src/tf2jax.py:343–367`
+
+## Definition
+
+```python
+class Variable(np.ndarray):
+    trainable: bool
+    name: str
+    
+    def __new__(cls, arr, trainable, name):
+        obj = np.asarray(arr).view(cls)
+        obj.trainable = trainable
+        obj.name = name
+        return obj
+    
+    def assign(self, arr):
+        return Variable(arr, trainable=self.trainable, name=self.name)
+    
+    def __array_finalize__(self, obj):
+        self.trainable = getattr(obj, "trainable", None)
+        self.name = getattr(obj, "name", None)
+```
+
+## Why NumPy, not JAX?
+
+`Variable` subclasses `np.ndarray` rather than `jax.Array` because:
+1. Variables are extracted outside of JIT by calling `tf_var.numpy()` at build time
+2. Users may want to inspect, modify, or checkpoint variables as plain NumPy before passing them to JAX functions
+3. NumPy arrays are accepted everywhere JAX arrays are via implicit conversion
+
+## Lifecycle
+
+1. **Created** in `_convert()` from `tf.Variable.numpy()` values
+2. **Returned** in the `params` dict from `convert()`
+3. **Passed** as the first argument to `jax_fn(params, *inputs)`
+4. **Updated** — if the model contains assign ops, `jax_fn` returns `new_params` with updated values
+5. **Inspected** — `params["dense/kernel"].trainable`, `params["dense/kernel"].name`
+
+## `params` dict conventions
+
+Keys are constructed from `tf.Variable.name` with `_parse_input` applied (strips the `:0` suffix) and uniquified if needed:
+
+```
+"dense/kernel"    → params["dense/kernel"]
+"dense/bias"      → params["dense/bias"]
+"dense/kernel:0"  → variable.name (original TF name)
+```
+
+## Related pages
+
+- [concepts/variable-semantics.md](../concepts/variable-semantics.md)
+- [entities/convert-api.md](convert-api.md)

--- a/wiki/entities/_GraphDef.md
+++ b/wiki/entities/_GraphDef.md
@@ -1,0 +1,83 @@
+# `_GraphDef` and `_NodeDef` — Synthetic Graph Types
+
+*Lightweight NamedTuples that mimic the TF protobuf types, used to represent library functions as graphs so `_convert` can handle both the top-level graph and inner functions uniformly.*
+
+**Source:** `tf2jax/_src/tf2jax.py:929–938`
+
+## The problem
+
+TF has two different graph representations:
+
+- **`tf.compat.v1.GraphDef`** (protobuf): produced by `concrete_func.graph.as_graph_def()`. Contains `node` (list of `NodeDef`) and `library` (a `FunctionDefLibrary` of `FunctionDef`s).
+- **`FunctionDef`** (protobuf): the format for library functions. Has `signature.input_arg`, `signature.output_arg`, `node_def`, and `ret` (output mapping) — a different structure from `GraphDef`.
+
+`_convert` is written to operate on graph-like objects with a flat `node` list. Library functions need to be converted by `_convert` too, but their proto structure doesn't match.
+
+## The solution: synthetic wrappers
+
+```python
+class _NodeDef(NamedTuple):
+    op: str
+    name: str
+    input: Tuple[str, ...]
+    attr: Optional[Mapping[str, tf.compat.v1.AttrValue]] = None
+
+class _GraphDef(NamedTuple):
+    node: Tuple[Union[tf.compat.v1.NodeDef, _NodeDef], ...]
+```
+
+`_convert_library_function` assembles a `_GraphDef` from a `FunctionDef` by synthesising nodes:
+
+```python
+# Each input_arg → Placeholder _NodeDef
+input_nodes = [_NodeDef("Placeholder", arg.name, (), {"dtype": ...})
+               for arg in proto.signature.input_arg]
+
+# Each output_arg → Identity _NodeDef  
+output_nodes = [_NodeDef("Identity", arg.name, (proto.ret[arg.name], ...), {"T": ...})
+                for arg in proto.signature.output_arg]
+
+graphdef = _GraphDef(tuple(input_nodes + list(proto.node_def) + output_nodes))
+```
+
+This transforms the `FunctionDef`'s `ret` mapping (output_name → node:idx string) into a standard `Identity` node that the existing graph traversal handles normally.
+
+## The Union type in `_convert`
+
+`_convert`'s signature accepts:
+
+```python
+def _convert(
+    graphdef: Union[tf.compat.v1.GraphDef, _GraphDef],
+    ...
+)
+```
+
+- Top-level calls (from `convert()`) pass a real `tf.compat.v1.GraphDef`
+- Library function calls (from `_convert_library_function`) pass a `_GraphDef`
+
+The distinction matters in one place:
+
+```python
+if hasattr(graphdef, "library"):   # True for real GraphDef, False for _GraphDef
+    # recurse into FunctionDefLibrary
+```
+
+Real `GraphDef`s have the `.library` attribute; synthetic `_GraphDef`s do not.
+
+## Cognitive load
+
+This Union type forces every reader of `_convert` to know both representations exist. A proposed fix (see [design/refactoring-recommendations.md](../design/refactoring-recommendations.md) item 5): normalise real `GraphDef`s into `_GraphDef` before calling `_convert`, so the function always receives one type. The `.library` recursion would happen in `convert()` before the call, not inside `_convert`.
+
+## `_NodeDef` vs `tf.compat.v1.NodeDef`
+
+Both have `.op`, `.name`, `.input`, `.attr`. `_NodeDef` is a NamedTuple; the proto version is a protobuf message. They are interchangeable for all purposes inside `_convert` because:
+- `_OpNode.__init__` accesses `proto.op`, `proto.name`, `proto.input`, `proto.attr` — all present on both
+- `_TensorEdge.from_string` uses `node_map[op_name].op` to look up `OpDef` — works on both
+
+## Related pages
+
+- [concepts/library-functions.md](../concepts/library-functions.md)
+- [concepts/conversion-phases.md](../concepts/conversion-phases.md)
+- [design/refactoring-recommendations.md](../design/refactoring-recommendations.md)
+- [entities/_OpNode.md](_OpNode.md)

--- a/wiki/entities/_HigherOrderFunction.md
+++ b/wiki/entities/_HigherOrderFunction.md
@@ -1,0 +1,66 @@
+# `_HigherOrderFunction`
+
+*Dataclass protocol for ops whose JAX implementation requires inner functions (control flow bodies, branch functions).*
+
+**Source:** `tf2jax/_src/ops.py:245–261`
+
+## Definition
+
+```python
+@dataclasses.dataclass
+class _HigherOrderFunction:
+    inner_fn_names: Mapping[str, str]   # kwarg name → library function name
+
+    def get_inner_functions(self, library_functions):
+        return {k: library_functions[v] for k, v in self.inner_fn_names.items()}
+
+    def get_additional_inputs(self, **inner_functions):
+        # Override in subclasses if the op needs extra input edges
+        # (e.g. VarHandleOp inputs for functions with checkpoint variables)
+        return ()
+```
+
+## How it integrates with `_OpNode`
+
+```python
+# In _OpNode.__init__:
+if isinstance(self.jax_func, ops._HigherOrderFunction):
+    self.inner_fns = self.jax_func.get_inner_functions(library)
+    for input_name in self.jax_func.get_additional_inputs(**self.inner_fns):
+        inputs.append(_TensorEdge.from_string(input_name, node_map))
+
+# In _OpNode.__call__:
+extras_dict.update(self.inner_fns)
+outputs = self.jax_func(*unboxed_args, **extras_dict)
+```
+
+The op factory returns a `_HigherOrderFunction` instance (not a plain callable). `_OpNode` detects this via `isinstance`, fetches the inner `_LibraryFunction`s, and passes them as keyword arguments at run time.
+
+## Implemented by
+
+**`_CaseOp`** — `tf.switch_case` / `tf.raw_ops.Case`:
+```python
+class _CaseOp(_HigherOrderFunction):
+    def __call__(self, branch_index, *operand, **branch_fns):
+        branches = [lambda args: fn(*args) for _, fn in sorted(branch_fns.items())]
+        return jax.lax.switch(branch_index, branches=branches, operand=operand)
+```
+
+**`_WhileOp`** — `tf.while_loop`: maps to `jax.lax.while_loop(cond_fn, body_fn, init_val)`
+
+**`_IfOp`** — `tf.cond`: maps to `jax.lax.cond(pred, true_fn, false_fn, *operands)`
+
+**`_MapFnOp`** — `tf.map_fn`: maps to `jax.vmap` or `jax.lax.map`
+
+**`_XlaReduceWindow`** — uses `computation` inner function for custom reduce windows
+
+## `get_additional_inputs`
+
+Some higher-order functions contain `VarHandleOp` nodes that reference variables from checkpoints. These variables need to be threaded in as explicit inputs. `get_additional_inputs` returns their names so `_OpNode` can add them as extra `_TensorEdge`s.
+
+## Related pages
+
+- [entities/_OpNode.md](_OpNode.md)
+- [entities/_LibraryFunction.md](_LibraryFunction.md)
+- [concepts/library-functions.md](../concepts/library-functions.md)
+- [concepts/op-registry.md](../concepts/op-registry.md)

--- a/wiki/entities/_LibraryFunction.md
+++ b/wiki/entities/_LibraryFunction.md
@@ -1,0 +1,70 @@
+# `_LibraryFunction`
+
+*A lazily-compiled JAX function corresponding to a TF `FunctionDef`, with metadata about its inputs, outputs, and RNG requirements.*
+
+**Source:** `tf2jax/_src/tf2jax.py:187–217`
+
+## Definition
+
+```python
+class _LibraryFunction(NamedTuple):
+    fn_builder: _CachedBuilder          # lazy: build JAX fn on first call
+    require_rng: bool                   # does this fn (or any inner fn) use random ops?
+    input_specs: Optional[Tuple[tf.TensorSpec, ...]]   # specs of all inputs
+    output_specs: Optional[Tuple[tf.TensorSpec, ...]]  # specs of all outputs
+    # Gradient function only:
+    orig_fn_output_specs: Optional[Tuple[tf.TensorSpec, ...]]  # outputs of original fn
+    output_is_input: Optional[Tuple[bool]]  # which outputs are unmodified inputs
+    variable_input_specs: Optional[Tuple[tf.TensorSpec, ...]]  # VarHandleOp inputs
+```
+
+### Properties
+
+```python
+@property
+def fn(self):
+    fn, _ = self.fn_builder()   # triggers lazy compilation on first access
+    return fn
+
+@property
+def params(self):
+    _, params = self.fn_builder()
+    return params
+
+def __call__(self, *args, **kwargs):
+    if self.params:
+        return self.fn(self.params, *args, **kwargs)
+    else:
+        return self.fn({}, *args, **kwargs)[0]
+```
+
+Calling `fn_builder()` the first time triggers `_convert()` on the library function's synthesised `_GraphDef`. The result is cached by `_CachedBuilder` (via `lru_cache`), so subsequent calls are free.
+
+## Two creation paths
+
+**Library function** (from `_convert_library_function`):
+- Created for each `FunctionDef` in `FunctionDefLibrary`
+- `require_rng` computed from node ops + inner function flags
+- `orig_fn_output_specs` is `None`
+
+**Gradient function** (from `_convert_gradient_function`):
+- Created for each `@tf.custom_gradient` gradient function
+- `orig_fn_output_specs` = output specs of the original decorated function (needed to split `IdentityN` inputs)
+- `input_specs` = specs of all inputs to the `IdentityN` node (used by `_Subgraph`)
+
+## Name collision
+
+`ops.py` also defines a `_LibraryFunction` as a `Protocol`:
+
+```python
+class _LibraryFunction(Protocol):
+    variable_input_specs: Optional[Tuple[tf.TensorSpec, ...]] = None
+```
+
+This is a different concept — it describes "anything with `variable_input_specs`" and is used as a type hint in `_HigherOrderFunction.get_additional_inputs`. The name overlap with the concrete `NamedTuple` in `tf2jax.py` is a known confusability issue.
+
+## Related pages
+
+- [concepts/library-functions.md](../concepts/library-functions.md)
+- [entities/_Subgraph.md](_Subgraph.md)
+- [entities/_HigherOrderFunction.md](_HigherOrderFunction.md)

--- a/wiki/entities/_OpNode.md
+++ b/wiki/entities/_OpNode.md
@@ -1,0 +1,93 @@
+# `_OpNode`
+
+*Wraps a TF `NodeDef` proto, bakes in its static attributes at build time, and provides a uniform call interface for the evaluation loop.*
+
+**Source:** `tf2jax/_src/tf2jax.py:239–295`
+
+## Construction
+
+```python
+class _OpNode:
+    def __init__(self, proto, library, node_map):
+        self.jax_func = ops.get_parser(proto.op)(proto)   # factory → jax callable
+        self.op = proto.op
+        self.name = proto.name
+        
+        inputs = [_TensorEdge.from_string(inp, node_map) for inp in proto.input]
+        
+        self.inner_fns = {}
+        if isinstance(self.jax_func, ops._HigherOrderFunction):
+            self.inner_fns = self.jax_func.get_inner_functions(library)
+            # higher-order ops may need extra input edges (e.g. VarHandleOp variables)
+            for input_name in self.jax_func.get_additional_inputs(**self.inner_fns):
+                inputs.append(_TensorEdge.from_string(input_name, node_map))
+        
+        self.control_inputs = tuple(inp for inp in inputs if inp.is_control)
+        self.inputs = tuple(inp for inp in inputs if not inp.is_control)
+```
+
+`ops.get_parser(proto.op)` retrieves the factory function from `_jax_ops`, then immediately calls it with `proto`. The factory reads all static attributes (strides, padding, dtype, axis, etc.) and returns a JAX callable closed over them. That callable is stored as `self.jax_func`.
+
+## `require_rng`
+
+```python
+@property
+def require_rng(self) -> bool:
+    inner_require_rngs = any(fn.require_rng for fn in self.inner_fns.values())
+    return self.op in _TF_RANDOM_OPS or inner_require_rngs
+```
+
+`_TF_RANDOM_OPS = ("RandomStandardNormal", "RandomUniform", "RandomUniformInt")`. Higher-order ops propagate the flag from their inner functions.
+
+## `__call__`
+
+```python
+def __call__(self, named_args, *, rng):
+    unboxed_args = _unbox_named_args(named_args, self.inputs)
+    extras = dict(rng=rng) if self.require_rng else {}
+    extras.update(self.inner_fns)
+    outputs = self.jax_func(*unboxed_args, **extras)
+    
+    if self.op in _TF_ASSIGN_OPS:
+        updated_params = {named_args[0][0]: outputs}
+    else:
+        updated_params = {}
+    
+    return outputs, updated_params
+```
+
+`named_args` is a `list[(node_name, value)]` collected by the evaluation loop from `eval_cache.outputs`. `_unbox_named_args` validates names and extracts `value[inp.idx]` for tuple outputs.
+
+For assign ops, the first argument is the variable handle (its node name is the variable's cache key), so `named_args[0][0]` gives the correct key for `updated_params`.
+
+## Protocol shared with `_Subgraph`
+
+Both `_OpNode` and `_Subgraph` implement:
+
+| Attribute/Method | Type | Purpose |
+|----------|------|---------|
+| `.name` | `str` | unique node name, used as cache key |
+| `.inputs` | `Tuple[_TensorEdge]` | data input edges |
+| `.control_inputs` | `Tuple[_TensorEdge]` | control dependency edges |
+| `.require_rng` | `bool` | whether this node needs a PRNG key |
+| `.__call__(named_args, *, rng)` | — | executes the node, returns `(outputs, updated_params)` |
+
+There is no formal interface declaration. See [design/refactoring-recommendations.md](../design/refactoring-recommendations.md) for a proposal to add a `_GraphNode` Protocol.
+
+## `__repr__`
+
+```
+_OpNode(name='dense/MatMul', op='MatMul', inputs=['x', 'kernel'])
+```
+
+## Variable mutation note
+
+`_infer_relu_from_jax2tf` mutates `_OpNode` instances in-place (`.op`, `.inputs`, `.jax_func`). This is the only place in the codebase where nodes are modified after construction.
+
+## Related pages
+
+- [concepts/op-registry.md](../concepts/op-registry.md)
+- [concepts/graph-evaluation.md](../concepts/graph-evaluation.md)
+- [entities/_TensorEdge.md](_TensorEdge.md)
+- [entities/_Subgraph.md](_Subgraph.md)
+- [entities/_HigherOrderFunction.md](_HigherOrderFunction.md)

--- a/wiki/entities/_Subgraph.md
+++ b/wiki/entities/_Subgraph.md
@@ -1,0 +1,114 @@
+# `_Subgraph`
+
+*A group of nodes whose forward computation is wrapped with `jax.custom_gradient`, used to implement `@tf.custom_gradient` sites.*
+
+**Source:** `tf2jax/_src/tf2jax.py:606–736`
+
+## Structure
+
+```python
+class _Subgraph(NamedTuple):
+    subgraph: Tuple[_OpNode, ...]      # nodes in forward computation (excl. output_node)
+    captures: Tuple[_TensorEdge, ...]  # inputs from outside the subgraph (external)
+    outputs: Tuple[_TensorEdge, ...]   # which IdentityN inputs are forward outputs
+    output_node: _OpNode               # the IdentityN _OpNode
+    grad_fn: _LibraryFunction          # the converted gradient function
+```
+
+### Computed properties
+
+```python
+@property
+def function_inputs(self):
+    # IdentityN inputs beyond the forward outputs
+    return tuple(self.output_node.inputs[len(self.outputs):])
+
+@property
+def unique_inputs(self):
+    # function_inputs + unique external captures not already in function_inputs
+    return self.function_inputs + unique_captures
+
+# Implements the _GraphNode protocol:
+name = output_node.name
+inputs = function_inputs + captures
+control_inputs = ()
+require_rng = any(n.require_rng for n in subgraph)
+```
+
+## Forward execution
+
+On each call, `__call__` defines a new `@jax.custom_gradient`-decorated function `fn`:
+
+```python
+@jax.custom_gradient
+def fn(*args):  # args = unboxed unique_inputs
+    # 1. Set up eval_cache with named_args + grad residuals slots
+    eval_cache = _EvaluationCache(
+        self.subgraph, named_args, self.output_node.inputs + grad_inputs)
+    
+    # 2. Populate cache with the unique_inputs values
+    for inp, val in zip(self.unique_inputs, args):
+        eval_cache.outputs[inp.op_name] = val  # (with tuple splicing for multi-output nodes)
+    
+    # 3. Execute subgraph + output_node in order
+    for node in self.subgraph + (self.output_node,):
+        eval_cache.outputs[node.name], _ = node(collected_inputs, rng=sub_rng)
+        eval_cache.free_inputs(node)
+    
+    # 4. Define and return the grad function
+    def grad_fn(dy):
+        captured_inputs = grad_inputs[len(dy):]
+        captures = _unbox_named_args(
+            [(v.op_name, eval_cache.outputs[v.op_name]) for v in captured_inputs],
+            captured_inputs)
+        dx = self.grad_fn(*dy, *captures)
+        return dx
+    
+    return eval_cache.outputs[self.output_node.name], grad_fn
+```
+
+Note: `@jax.custom_gradient` is re-applied on every call because it's defined inside `__call__`. This is wasteful but correct.
+
+## `rewrite(nodes)`
+
+Removes the subgraph's individual `_OpNode`s from the main node list and inserts `self` at the position of `output_node`:
+
+```python
+def rewrite(self, nodes):
+    new_nodes = []
+    subgraph_map = {v.name: v for v in self.subgraph + (self.output_node,)}
+    for node in nodes:
+        if node.name in subgraph_map:
+            if node == self.output_node:
+                new_nodes.append(self)  # replace with _Subgraph
+            # else: drop (it's an internal subgraph node)
+        else:
+            # Rewire control inputs that pointed into the subgraph
+            new_nodes.append(node_with_rewired_control_inputs)
+    return tuple(new_nodes)
+```
+
+After `rewrite`, `_Subgraph` is callable via the same interface as `_OpNode`.
+
+## Grad function calling convention
+
+`self.grad_fn` is the `_LibraryFunction` for the registered gradient function. It is called with:
+- `dy`: upstream gradients, one per `output_node.inputs` (length = `num_outputs + num_function_inputs`)
+- `captures`: additional inputs to the gradient function beyond `output_node.inputs`, sourced from `eval_cache` (kept alive by the `eval_cache` not freeing their slots due to the `grad_inputs` output list)
+
+## Limitations
+
+1. **Variable assignments** inside the subgraph raise `ValueError` — the eval loop does not handle `updated_params` inside `_Subgraph`.
+2. **Overlapping subgraphs** raise `ValueError` — checked in `_extract_subgraphs` after all subgraphs are found.
+3. **Missing gradient function** — if `grad_fn is None` (not serialized in the SavedModel), the `IdentityN` is skipped and falls back to automatic differentiation.
+
+## Future: lazy custom gradients
+
+Currently `@jax.custom_gradient` is reinstated on every forward call, and the gradient function TF tracing (`get_concrete_function`) happens eagerly at `convert()` time. A redesign using `jax.custom_vjp` would make the backward truly lazy. See [design/lazy-custom-gradients.md](../design/lazy-custom-gradients.md).
+
+## Related pages
+
+- [concepts/custom-gradients.md](../concepts/custom-gradients.md)
+- [entities/_OpNode.md](_OpNode.md)
+- [entities/_LibraryFunction.md](_LibraryFunction.md)
+- [design/lazy-custom-gradients.md](../design/lazy-custom-gradients.md)

--- a/wiki/entities/_TensorEdge.md
+++ b/wiki/entities/_TensorEdge.md
@@ -1,0 +1,49 @@
+# `_TensorEdge`
+
+*Represents a directed edge in the computation graph: a reference to a specific output tensor of a node.*
+
+**Source:** `tf2jax/_src/tf2jax.py:106–157`
+
+## Definition
+
+```python
+class _TensorEdge(NamedTuple):
+    op_name: str        # the producing node's name (cache key)
+    idx: int = 0        # which output of that node (0 for single-output ops)
+    is_control: bool = False   # True for control dependencies (^NodeName)
+```
+
+## Construction from proto string
+
+TF `NodeDef.input` entries are strings in one of these formats:
+
+| Format | Meaning |
+|--------|---------|
+| `"NodeName"` | output 0 of NodeName |
+| `"NodeName:2"` | output 2 of NodeName |
+| `"NodeName:output_name:0"` | named output (multi-output ops) |
+| `"^NodeName"` | control dependency on NodeName |
+
+`_TensorEdge.from_string(op_str, node_map)` parses these. For the three-part format, it looks up the `OpDef` in the TF op registry to resolve `output_name` to an integer index.
+
+## Usage
+
+`_TensorEdge` objects are stored in:
+- `_OpNode.inputs` and `_OpNode.control_inputs`
+- `_Subgraph.captures`, `_Subgraph.outputs`
+- `output_args` list in `_convert` (which outputs to read from `eval_cache`)
+
+The evaluation loop collects inputs for a node as:
+
+```python
+collected_inputs = [
+    (v.op_name, eval_cache.outputs[v.op_name]) for v in node.inputs
+]
+```
+
+`op_name` is the cache key; `idx` is used in `_unbox_named_args` to index into tuple outputs.
+
+## Related pages
+
+- [entities/_OpNode.md](_OpNode.md)
+- [concepts/graph-evaluation.md](../concepts/graph-evaluation.md)

--- a/wiki/entities/convert-api.md
+++ b/wiki/entities/convert-api.md
@@ -1,0 +1,112 @@
+# Public API: `convert`, `convert_functional`, `convert_from_restored`
+
+*Three entry points covering the main use cases: general conversion, stateless functions, and SavedModel restoration.*
+
+**Source:** `tf2jax/_src/tf2jax.py:461–570` (`convert`), `394–399` (`convert_functional`), `402–425` (`convert_from_restored`)
+
+---
+
+## `convert(tf_func, *args, **kwargs)`
+
+The primary entry point.
+
+```python
+jax_fn, params = tf2jax.convert(tf_model, *sample_inputs)
+```
+
+**Returns:** `(AnnotatedFunction, dict[str, Variable])`
+
+The `AnnotatedFunction` wraps a `jax_func(params, *args, rng=None, **kwargs)` callable that returns `(outputs, new_params)`.
+
+**What it does:**
+1. Calls `tf_func.get_concrete_function(*args, **kwargs)` to get a `ConcreteFunction`
+2. Extracts `GraphDef`, `captures` (variables + constants), input/output specs
+3. Optionally converts custom gradient functions (`_convert_all_gradient_functions`)
+4. Calls `_convert(graphdef, ...)` to build the JAX function
+
+**Args** can be `tf.TensorSpec` (abstract), actual tensors/arrays, or JAX tracers (they are automatically converted to `tf.TensorSpec` via `_maybe_tracer_to_tf_spec`).
+
+---
+
+## `convert_functional(tf_func, *args, **kwargs)`
+
+For functions with no `tf.Variable` captures.
+
+```python
+jax_fn = tf2jax.convert_functional(tf_model, *sample_inputs)
+outputs = jax_fn(*real_inputs)
+```
+
+**Returns:** `AnnotatedFunction` whose `__call__` takes just `(*args, **kwargs)` — no `params` argument, no `new_params` return.
+
+Raises if the function turns out to have captured variables.
+
+---
+
+## `convert_from_restored(tf_func)`
+
+For functions loaded from a `tf.saved_model.load()` (a `RestoredFunction`). Avoids specifying sample inputs explicitly.
+
+```python
+model = tf.saved_model.load("/path/to/model")
+jax_fn, params = tf2jax.convert_from_restored(model.signatures["serving_default"])
+```
+
+**How it determines the concrete function:**
+- If `tf_func.input_signature` is set: uses it as `args`
+- If not: checks `tf_func.concrete_functions` — if there's exactly one, uses its `structured_input_signature`. If there are multiple, raises with a helpful error showing the options.
+
+Delegates to `convert()` after resolving args.
+
+`convert_functional_from_restored` is the stateless variant.
+
+---
+
+## `AnnotatedFunction`
+
+```python
+class AnnotatedFunction:
+    fn: Callable               # the actual jax_func
+    structured_inputs: SpecTree
+    structured_outputs: SpecTree
+    __signature__: inspect.Signature   # mirrors the original TF function's signature
+    __name__: str
+    __doc__: str
+    
+    def __call__(self, *args, **kwargs):
+        return self.fn(*args, **kwargs)
+```
+
+Preserves the original function's signature for debugging and introspection tools. The `structured_inputs`/`structured_outputs` fields carry the `tf.TensorSpec` tree describing the expected I/O.
+
+---
+
+## Config flags affecting conversion
+
+| Flag | Default | Effect |
+|------|---------|--------|
+| `convert_custom_gradient` | `True` | Convert `@tf.custom_gradient` sites |
+| `strict_shape_check` | `True` | Validate input shapes at run time |
+| `strict_dtype_check` | `False` | Validate input dtypes at run time |
+| `infer_relu_from_jax2tf` | `True` | Detect `max(x,0)` patterns from jax2tf output |
+| `infer_cumulative_reduction_from_jax2tf` | `True` | Detect cumsum/cumprod patterns |
+| `skip_variables_evaluation_inside_tf_tracing` | `False` | Needed when calling `convert` inside `tf.function` |
+
+Use `tf2jax.override_config(name, value)` as a context manager, or `tf2jax.update_config(name, value)` for permanent changes.
+
+---
+
+## TF-Hub compatibility
+
+TF-Hub modules may use `$` in tensor names and may have `VariableSpec` objects mixed into structured specs. Three workarounds exist:
+
+- `_fix_tfhub_specs`: rewrites tensor names in structured specs to match the concrete function's tensor names
+- `_UNUSED_INPUT`: sentinel for tensor arguments that were unused in the traced function
+- `k.replace("$", "___")` substitution in parameter names (because `$` is not a valid Python identifier)
+
+## Related pages
+
+- [overview.md](../overview.md)
+- [concepts/conversion-phases.md](../concepts/conversion-phases.md)
+- [concepts/variable-semantics.md](../concepts/variable-semantics.md)
+- [entities/_convert.md](_convert.md)

--- a/wiki/entities/jax2tf-heuristics.md
+++ b/wiki/entities/jax2tf-heuristics.md
@@ -1,0 +1,96 @@
+# jax2tf Pattern-Matching Heuristics
+
+*Two post-processing passes that detect and replace patterns introduced by `jax2tf.convert`, restoring cleaner JAX equivalents.*
+
+**Source:** `tf2jax/_src/tf2jax.py:877–899` (`_infer_relu_from_jax2tf`), `tf2jax/_src/ops.py:2708–2773` (cumulative reduction, inside `_XlaReduceWindow`)
+
+---
+
+## `_infer_relu_from_jax2tf`
+
+**What it detects:** `Maximum(x, Cast(Const(0)))` — jax2tf's lowering of `jax.nn.relu`.
+
+**How it works:**
+
+```python
+def _infer_relu_from_jax2tf(nodes):
+    node_map = {n.name: n for n in nodes}
+    for node in nodes:
+        if node.op == "Maximum" and "jax2tf" in node.name and "_relu_" in node.name:
+            cast_or_const_arg = node_map[node.inputs[1].op_name]
+            if cast_or_const_arg.op == "Cast":
+                const_arg = node_map[cast_or_const_arg.inputs[0].op_name]
+            else:
+                const_arg = cast_or_const_arg
+            
+            if const_arg.op == "Const" and const_arg((), rng=None)[0].tolist() == 0:
+                node.op = "Relu"
+                node.inputs = node.inputs[:1]
+                node.jax_func = ops.get_parser("Relu")(_NodeDef("Relu", node.name, (), {}))
+```
+
+Matching uses both the node op type (`Maximum`) and the node name (`"jax2tf"` and `"_relu_"` substrings), so it only fires on graphs produced by jax2tf, not on arbitrary user-written `max(x, 0)` patterns.
+
+**Why it matters:** `jax.nn.relu` has a well-defined gradient (subgradient at 0). `jnp.maximum(x, 0)` computes the same values but JAX differentiates it via its general maximum rule, which can differ at exactly 0. Using `relu` directly also produces a cleaner JIT-compiled program.
+
+**Side effect:** This is the only place in the codebase where `_OpNode` objects are **mutated after construction** — `.op`, `.inputs`, and `.jax_func` are all overwritten in-place. The `Cast` and `Const` nodes that fed the replaced zero argument become orphaned (their reference counts drop to zero and `_EvaluationCache` frees them).
+
+**Controlled by:** `infer_relu_from_jax2tf` config flag (default `True`).
+
+---
+
+## Cumulative reduction inference (inside `_XlaReduceWindow`)
+
+**What it detects:** `reduce_window` calls with window patterns matching `cumsum`, `cumprod`, `cummax`, or `cummin`.
+
+**Background:** jax2tf lowers `jax.lax.cumsum` as `jax.lax.reduce_window` with a specific window/padding pattern. The resulting `XlaReduceWindow` op in the TF graph is correct but opaque — JAX treats it as a general reduce_window and cannot recognize it as a cumulative reduction for VJP purposes.
+
+**How it works:** Inside the `_XlaReduceWindow` op's runtime function, after converting the abstract `computation` function to a JAX primitive:
+
+```python
+def infer_cumulative_reduction():
+    # Check: window spans the full reduce axis, stride 1, no dilation
+    reduce_axis = np.argmax(window_dimensions)
+    reduce_dim = operand.shape[reduce_axis]
+    dims = [1] * ndims; dims[reduce_axis] = reduce_dim
+    if not (window_dimensions == dims and window_strides == [1]*ndims ...):
+        return (None, None, None)
+    
+    # Check padding: [reduce_dim-1, 0] → forward; [0, reduce_dim-1] → reverse
+    if padding == normal_padding:  reverse = False
+    elif padding == reverse_padding: reverse = True
+    else: return (None, None, None)
+    
+    # Match computation to a known cumulative reduction
+    if computation_fn is jax.lax.add and init_value == 0:
+        return (jax.lax.cumsum, reduce_axis, reverse)
+    elif computation_fn is jax.lax.mul and init_value == 1:
+        return (jax.lax.cumprod, reduce_axis, reverse)
+    elif computation_fn is jax.lax.max and init_value == _get_max_identity(dtype):
+        return (jax.lax.cummax, reduce_axis, reverse)
+    elif computation_fn is jax.lax.min and init_value == _get_min_identity(dtype):
+        return (jax.lax.cummin, reduce_axis, reverse)
+```
+
+If a match is found and `infer_cumulative_reduction_from_jax2tf` is set, the function returns `jax.lax.cumsum(operand, ...)` directly instead of `jax.lax.reduce_window(...)`.
+
+**Why it matters:** `jax.lax.cumsum` has an efficient parallel scan VJP. A general `reduce_window` does not. Recognising the pattern restores the efficient gradient.
+
+**Controlled by:** `infer_cumulative_reduction_from_jax2tf` config flag (default `True`).
+
+---
+
+## Comparison
+
+| | `_infer_relu_from_jax2tf` | Cumulative reduction inference |
+|--|--|--|
+| Applied | Build time (after node construction) | Run time (inside op execution) |
+| Mechanism | Mutates `_OpNode` in-place | Branch in `_XlaReduceWindow.__call__` |
+| Scope | Entire node list | Individual `XlaReduceWindow` call |
+| Detection signal | Node name + op type + constant value | Window shape + padding + computation primitive |
+
+## Related pages
+
+- [concepts/jax2tf-roundtrip.md](../concepts/jax2tf-roundtrip.md)
+- [entities/_OpNode.md](_OpNode.md)
+- [concepts/graph-evaluation.md](../concepts/graph-evaluation.md)

--- a/wiki/index.md
+++ b/wiki/index.md
@@ -1,0 +1,66 @@
+# Wiki Index
+
+*Content-oriented catalog of all pages. Read this first when looking for a specific topic.*
+
+---
+
+## Overview
+
+| Page | Summary |
+|------|---------|
+| [overview.md](overview.md) | Architecture overview: what tf2jax does, the 3-layer data model, build vs run time, module map |
+
+---
+
+## Concepts
+
+Core mechanisms and design patterns.
+
+| Page | Summary |
+|------|---------|
+| [concepts/conversion-phases.md](concepts/conversion-phases.md) | Build time vs run time: what `_convert()` does before and inside `jax_func`; the 12 captured variables |
+| [concepts/op-registry.md](concepts/op-registry.md) | The `_jax_ops` dict, two-level factory pattern, `register_operation()` decorator, dispatch via `get_parser()` |
+| [concepts/graph-evaluation.md](concepts/graph-evaluation.md) | Topological sort, `_EvaluationCache` reference counting, the evaluation loop, named-arg protocol, variable assignment handling |
+| [concepts/variable-semantics.md](concepts/variable-semantics.md) | TF variables → JAX params dict; extraction, threading, functional update semantics |
+| [concepts/custom-gradients.md](concepts/custom-gradients.md) | `IdentityN` detection, subgraph extraction, `jax.custom_gradient` wrapping, gradient function conversion pipeline |
+| [concepts/library-functions.md](concepts/library-functions.md) | `FunctionDefLibrary`, `_CachedBuilder` lazy compilation, `_LibraryFunction`, higher-order op integration |
+| [concepts/numpy-compat.md](concepts/numpy-compat.md) | Dual `np`/`jnp` dispatch layer, polymorphic dimension handling, dtype tables |
+| [concepts/jax2tf-roundtrip.md](concepts/jax2tf-roundtrip.md) | JAX→TF→JAX round-trip use case; what jax2tf does to graphs and how tf2jax handles it |
+
+---
+
+## Entities
+
+Specific classes, functions, and modules.
+
+| Page | Summary |
+|------|---------|
+| [entities/convert-api.md](entities/convert-api.md) | `convert()`, `convert_functional()`, `convert_from_restored()`, `AnnotatedFunction`, config flags |
+| [entities/_OpNode.md](entities/_OpNode.md) | Wraps `NodeDef` proto, bakes static attrs at build time, uniform call interface for evaluation loop |
+| [entities/_Subgraph.md](entities/_Subgraph.md) | Group of nodes wrapped with `jax.custom_gradient`; `rewrite()` splices it into the main node list |
+| [entities/_TensorEdge.md](entities/_TensorEdge.md) | Edge in the computation graph: `(op_name, idx, is_control)` parsed from proto input strings |
+| [entities/_LibraryFunction.md](entities/_LibraryFunction.md) | Lazily-compiled JAX function from a `FunctionDef`; holds specs and `_CachedBuilder` |
+| [entities/_HigherOrderFunction.md](entities/_HigherOrderFunction.md) | Dataclass protocol for control flow ops that need inner function kwargs at call time |
+| [entities/Variable.md](entities/Variable.md) | NumPy `ndarray` subclass carrying `trainable` and `name`; lives in the `params` dict |
+| [entities/_GraphDef.md](entities/_GraphDef.md) | Synthetic `_GraphDef`/`_NodeDef` NamedTuples that let `_convert` handle both real GraphDefs and library functions uniformly |
+| [entities/jax2tf-heuristics.md](entities/jax2tf-heuristics.md) | `_infer_relu_from_jax2tf` and cumulative reduction inference: pattern-matching passes that restore clean JAX ops from jax2tf artifacts |
+
+---
+
+## Design
+
+Design proposals, refactoring notes, trade-off records.
+
+| Page | Summary |
+|------|---------|
+| [design/refactoring-recommendations.md](design/refactoring-recommendations.md) | 7 structural improvements: `_CompiledGraph` class, `_GraphNode` protocol, custom gradient module, name collision fixes |
+| [design/lazy-custom-gradients.md](design/lazy-custom-gradients.md) | Full design for deferring gradient function TF tracing to first backward call using `jax.custom_vjp` |
+
+---
+
+## Schema and meta
+
+| Page | Summary |
+|------|---------|
+| [SCHEMA.md](SCHEMA.md) | Wiki conventions, directory structure, ingest/query/lint workflows |
+| [log.md](log.md) | Append-only chronological record of wiki activity |

--- a/wiki/log.md
+++ b/wiki/log.md
@@ -1,0 +1,64 @@
+# Log
+
+*Append-only chronological record of wiki activity.*
+
+Format: `## [YYYY-MM-DD] operation | description`
+
+---
+
+## [2026-04-12] bootstrap | Initial wiki creation
+
+**Operation:** Initial codebase analysis and wiki bootstrap.
+
+**Sources read:**
+- Full codebase exploration via Explore agent (thorough analysis)
+- Direct reads: `tf2jax.py` (all sections), `ops.py` (all sections), `numpy_compat.py`, `config.py`, `utils.py`, `xla_utils.py`
+
+**Pages created:**
+- `SCHEMA.md` — wiki conventions
+- `index.md` — content catalog
+- `log.md` — this file
+- `overview.md` — architecture overview
+- `concepts/conversion-phases.md`
+- `concepts/op-registry.md`
+- `concepts/graph-evaluation.md`
+- `concepts/variable-semantics.md`
+- `concepts/custom-gradients.md`
+- `concepts/library-functions.md`
+- `concepts/numpy-compat.md`
+- `entities/convert-api.md`
+- `entities/_OpNode.md`
+- `entities/_Subgraph.md`
+- `entities/_TensorEdge.md`
+- `entities/_LibraryFunction.md`
+- `entities/_HigherOrderFunction.md`
+- `entities/Variable.md`
+- `design/refactoring-recommendations.md`
+- `design/lazy-custom-gradients.md`
+
+**Context:** Extended conversation covering design review, refactoring recommendations (high-level), and the lazy custom gradients design. All findings from that conversation are encoded in the wiki.
+
+**Notable findings:**
+- The 12-variable closure in `_convert` is the main cognitive load issue
+- Custom gradient code (~350 lines) is entangled with core conversion in `tf2jax.py`
+- `_LibraryFunction` name collision between `tf2jax.py` (NamedTuple) and `ops.py` (Protocol)
+- TF tracing of gradient functions is eager even for inference-only use; design for lazy fix is in `design/lazy-custom-gradients.md`
+- The JAX conversion inside `_CachedBuilder` is already lazy; only TF tracing is not
+
+**Gaps / pages not yet written:**
+- `entities/_EvaluationCache.md`
+- `entities/config.md` (the 11 config flags)
+- `entities/experimental.md` (XlaCallModule, StableHLO)
+- `concepts/tfhub-compatibility.md` (the `_UNUSED_INPUT`, `_fix_tfhub_specs` workarounds)
+
+---
+
+## [2026-04-12] ingest | Gap-fill: 4 missing topics from session
+
+**Pages added:**
+- `concepts/jax2tf-roundtrip.md` — the JAX→TF→JAX use case and what it drives
+- `entities/jax2tf-heuristics.md` — `_infer_relu_from_jax2tf` and cumulative reduction inference
+- `entities/_GraphDef.md` — synthetic `_GraphDef`/`_NodeDef` types and the Union type in `_convert`
+- Updated `concepts/graph-evaluation.md` — expanded named-arg protocol section with reasoning
+
+**Also updated:** `index.md` entries for new pages; log gaps list trimmed.

--- a/wiki/overview.md
+++ b/wiki/overview.md
@@ -1,0 +1,82 @@
+# Architecture Overview
+
+*tf2jax converts TensorFlow functions to JAX functions by transpiling computational graphs, not by interpreting eager execution.*
+
+## What it does
+
+Given a `tf.Function`, tf2jax returns an equivalent JAX function and a dict of parameters (the captured TF Variables). The JAX function is purely functional: variables become explicit positional parameters, and updates are returned rather than applied in-place.
+
+```python
+jax_fn, params = tf2jax.convert(tf_model, *sample_inputs)
+outputs, new_params = jax_fn(params, *real_inputs)
+```
+
+## Three-layer data model
+
+```
+tf.Function
+    │  trace with sample inputs
+    ▼
+tf.ConcreteFunction  (GraphDef + captured variables)
+    │  _convert()
+    ▼
+[_OpNode, _OpNode, _Subgraph, ...]   ← topologically sorted, build time
+    │  jax_func closure / CompiledGraph
+    ▼
+JAX arrays                           ← run time
+```
+
+## Two phases: build time vs run time
+
+This is the most important mental model for reading the code.
+
+**Build time** (happens once, inside `convert()` and `_convert()`):
+- TF function is traced with sample inputs → `ConcreteFunction`
+- `GraphDef` is extracted
+- Library functions (`FunctionDefLibrary`) are recursively converted
+- Custom gradient functions are traced (TF) and registered
+- Nodes are topologically sorted
+- `_OpNode` wrappers are built (each calls `ops.get_parser(proto.op)(proto)` to bake in static attributes)
+- Custom gradient subgraphs are detected and nodes are rewritten to `_Subgraph` objects
+- A `jax_func` closure (or future: `_CompiledGraph`) is returned, capturing all build-time state
+
+**Run time** (every call to `jax_func`):
+- User args are bound to the signature
+- Input shapes/dtypes are checked against specs
+- `_EvaluationCache` is initialized
+- Nodes are executed in topological order
+- Variable assignments are tracked and returned
+
+## Module map
+
+| Module | Role |
+|--------|------|
+| `tf2jax/_src/tf2jax.py` | Conversion engine, public API, `_OpNode`, `_Subgraph`, `_LibraryFunction`, `Variable` |
+| `tf2jax/_src/ops.py` | Op registry (`_jax_ops`), `register_operation()`, `_HigherOrderFunction`, 150+ op implementations |
+| `tf2jax/_src/numpy_compat.py` | Dual NumPy/JAX-NumPy dispatch layer for constant folding during conversion |
+| `tf2jax/_src/config.py` | 11 global config flags with context-manager overrides |
+| `tf2jax/_src/xla_utils.py` | XLA protobuf helpers (convolution/dot/gather dimension numbers) |
+| `tf2jax/_src/utils.py` | `fullargspec_to_signature`, `safe_zip` |
+| `tf2jax/experimental/ops.py` | `XlaCallModule` support (native serialization from jax2tf) |
+| `tf2jax/experimental/mhlo.py` | MLIR/StableHLO dialect abstractions |
+
+## Public API
+
+See [entities/convert-api.md](entities/convert-api.md).
+
+## Key design decisions
+
+1. **Graph-level transpilation** (not eager execution wrapping): the ConcreteFunction's GraphDef is parsed and each TF op is mapped to a JAX callable.
+2. **Variables become parameters**: `tf.Variable` → `Variable` (NumPy subclass) in the returned `params` dict. Functional update semantics.
+3. **Two-level op factory**: `_jax_ops[op_name]` holds a *factory* that takes a `NodeDef` proto and returns the actual JAX callable. Static attributes are baked in at build time.
+4. **Custom gradients via subgraph extraction**: `IdentityN` marker nodes are detected, the surrounding computation is extracted as a `_Subgraph`, and wrapped with `jax.custom_gradient`.
+5. **Lazy library function compilation**: `_CachedBuilder` ensures each library function is compiled at most once, with the config state frozen at compilation time.
+
+## Related pages
+
+- [concepts/conversion-phases.md](concepts/conversion-phases.md)
+- [concepts/op-registry.md](concepts/op-registry.md)
+- [concepts/graph-evaluation.md](concepts/graph-evaluation.md)
+- [concepts/variable-semantics.md](concepts/variable-semantics.md)
+- [concepts/custom-gradients.md](concepts/custom-gradients.md)
+- [concepts/library-functions.md](concepts/library-functions.md)


### PR DESCRIPTION
## Summary

- Adds a `wiki/` directory: an LLM-maintained knowledge base following the [Karpathy wiki pattern](https://gist.github.com/karpathy/442a6bf555914893e9891c11519de94f) — persistent, interlinked markdown files that compile codebase knowledge once rather than re-deriving it on every question
- 23 pages across overview, concepts, entities, and design sections
- Covers architecture, core mechanisms, all key classes, and design proposals from a deep review session

## Contents

**Concepts** — core mechanisms and patterns:
- Conversion phases (build time vs run time, the 12 captured closure variables)
- Op registry (two-level factory pattern, `register_operation`)
- Graph evaluation (toposort, `_EvaluationCache` reference counting, named-arg protocol)
- Variable semantics (TF variables → functional JAX params)
- Custom gradients (`IdentityN` detection, subgraph extraction pipeline)
- Library functions (`_CachedBuilder` lazy compilation, `FunctionDefLibrary`)
- NumPy compat (dual `np`/`jnp` dispatch, polymorphic shapes)
- jax2tf round-trip (what jax2tf does to graphs and how tf2jax handles it)

**Entities** — specific classes and functions:
- Public API (`convert`, `convert_functional`, `convert_from_restored`)
- `_OpNode`, `_Subgraph`, `_TensorEdge`, `_LibraryFunction`, `_HigherOrderFunction`, `Variable`
- `_GraphDef`/`_NodeDef` synthetic types and the dual graph representation
- jax2tf heuristics (`_infer_relu_from_jax2tf`, cumulative reduction inference)

**Design** — proposals and trade-off records:
- 7 structural refactoring recommendations (with priority table)
- Full design for lazy custom gradient evaluation using `jax.custom_vjp`

## Test plan

- [ ] Wiki is readable and links resolve correctly
- [ ] No source files modified

🤖 Generated with [Claude Code](https://claude.com/claude-code)