### PR TITLE
Fix "AttributeError" thrown when processing multiple subgraphs induced by custom gradient definitions

### DIFF
--- a/tf2jax/_src/tf2jax.py
+++ b/tf2jax/_src/tf2jax.py
@@ -712,7 +712,7 @@ class _Subgraph(NamedTuple):
 
   def rewrite(
       self,
-      nodes: Sequence[_OpNode]) -> Tuple[Union["_Subgraph", _OpNode], ...]:
+      nodes: Sequence[Union["_Subgraph", _OpNode]]) -> Tuple[Union["_Subgraph", _OpNode], ...]:
     """Remove subgraph from the main graph."""
     new_nodes = []
     processed = []
@@ -724,12 +724,27 @@ class _Subgraph(NamedTuple):
         if node == self.output_node:
           new_nodes.append(self)
       else:
-        # Rewire control inputs to point to the subgraph.
-        new_control_inputs = tuple(
-            v._replace(op_name=self.name) if v.op_name in subgraph_map else v
-            for v in node.control_inputs
-        )
-        node.control_inputs = new_control_inputs
+        try:
+          # "readonly_ci_prop" is True only when the type object of
+          # "node" contains an attribute "control_inputs", of which
+          # the value refers to another object having an attribute
+          # "fset" set to None
+          # => "control_inputs" behaves as a readonly property
+          readonly_ci_prop = type(node).control_inputs.fset is None
+        except AttributeError:
+          # If any of attribute read attemps above triggers
+          # "AttributeError"
+          # => control_inputs is not a property
+          readonly_ci_prop = False
+
+        if not readonly_ci_prop:
+          # Rewire control inputs to point to the subgraph.
+          new_control_inputs = tuple(
+              v._replace(op_name=self.name) if v.op_name in subgraph_map else v
+              for v in node.control_inputs
+          )
+          node.control_inputs = new_control_inputs
+
         new_nodes.append(node)
 
     assert len(processed) == len(subgraph), (len(processed), len(subgraph))


### PR DESCRIPTION
This tiny patch is intended to fix the problem described in the title, which is probably best explained with an example as follows.

Considering this simple case:

```python
import tensorflow as tf
import tf2jax

@tf.custom_gradient
def my_op(x):
  y = x**2
  def grad(dy):
    return dy * x * 2

  return y, grad

@tf.function
def func(z):
  return my_op(my_op(z))

with tf2jax.override_config("convert_custom_gradient", True):
  func_jaxed = tf2jax.convert_functional(func, np.zeros((2, 2), np.float32))
```
The conversion starts with generating a full graph depicted by `func()` and all op nodes involved:
```
nodes = [
  _OpNode(name='z'), _OpNode(name='pow/y'), _OpNode(name='pow'), _OpNode(name='IdentityN'),
  _OpNode(name='pow_1/y'), _OpNode(name='pow_1'), _OpNode(name='IdentityN_1'), _OpNode(name='Identity_2')
]
```
Since there are 2 calls to `my_op()`, which defines its own custom gradient, 2 subgraphs grouping associated nodes are extracted from the full graph:
```
# nodes belonging to _Subgraph(name='IdentityN')
[_OpNode(name='pow/y'), _OpNode(name='pow'), _OpNode(name='IdentityN')]

# nodes belonging to _Subgraph(name='IdentityN_1')
[_OpNode(name='pow_1/y'), _OpNode(name='pow_1'), _OpNode(name='IdentityN_1')]
```
Then the process goes on to update `nodes` to reflect the subgraph structures, supposedly resulting in:
```
nodes = [_OpNode(name='z'), _Subgraph(name='IdentityN'), _Subgraph(name='IdentityN_1'), _OpNode(name='Identity_2')]
```

Surprisingly, it turns out that tf2jax fails to convert this example and raises `AttributeError` at the converting stage above. This is because `_Subgraph.rewrite()` (defined in "tf2jax/_src/tf2jax.py"), which is the function responsible for manipulating `nodes` and subgraph substitution, treats every item in `nodes` as just a op node of the type `_OpNode`; however, this is not true after the addition of the 1st subgraph `_Subgraph(name='IdentityN')` to `nodes`, when the content of `nodes` becomes
```
# after "_Subgraph(name='IdentityN')" is substituted
nodes =  [
  _OpNode(name='z'), _Subgraph(name='IdentityN'), _OpNode(name='pow_1/y'),
  _OpNode(name='pow_1'), _OpNode(name='IdentityN_1'), _OpNode(name='Identity_2')
]
```
Therefore, as the subsequent call to `_Subgraph.rewrite()` on the 2nd subgraph `_Subgraph(name='IdentityN_1')` attempts to modify an attribute that is editable on `_OpNode` but read-only on `_Subgraph` while iterating `nodes`, an `AttributeError` exception occurs.

This fix takes into account the fact that `nodes` could be a mix of op nodes and subgraphs, and adds checks to avoid invalid attribute/property write attempts.